### PR TITLE
Return logout result

### DIFF
--- a/src/Auth0.OidcClient.Core/IAuth0Client.cs
+++ b/src/Auth0.OidcClient.Core/IAuth0Client.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using IdentityModel.OidcClient;
+using IdentityModel.OidcClient.Browser;
 using IdentityModel.OidcClient.Results;
 
 namespace Auth0.OidcClient
@@ -17,14 +18,14 @@ namespace Auth0.OidcClient
         /// Launches a browser to log the user out and clear the Auth0 SSO Cookie
         /// </summary>
         /// <returns></returns>
-        Task LogoutAsync();
+        Task<BrowserResultType> LogoutAsync();
 
         /// <summary>
         /// Launches a browser to log the user out and clear the Auth0 SSO Cookie
         /// </summary>
         /// <param name="federated">Indicates whether the user should also be logged out of their identity provider.</param>
         /// <returns></returns>
-        Task LogoutAsync(bool federated);
+        Task<BrowserResultType> LogoutAsync(bool federated);
 
         /// <summary>
         /// Generates an <see cref="IdentityModel.OidcClient.AuthorizeState"/> containing the URL, state, nonce and code challenge which can

--- a/src/Auth0.OidcClient.Shared/Auth0Client.cs
+++ b/src/Auth0.OidcClient.Shared/Auth0Client.cs
@@ -140,13 +140,13 @@ namespace Auth0.OidcClient
         /// Launches a browser to log the user out and clear the Auth0 SSO Cookie
         /// </summary>
         /// <returns></returns>
-        public Task LogoutAsync()
+        public Task<BrowserResultType> LogoutAsync()
         {
             return LogoutAsync(false);
         }
 
         /// <inheritdoc />
-        public async Task LogoutAsync(bool federated)
+        public async Task<BrowserResultType> LogoutAsync(bool federated)
         {
             var logoutUrl = $"https://{_options.Domain}/v2/logout";
 
@@ -164,6 +164,8 @@ namespace Auth0.OidcClient
                 Timeout = TimeSpan.FromSeconds((double) logoutRequest.BrowserTimeout),
                 DisplayMode = logoutRequest.BrowserDisplayMode
             });
+
+            return browserResult.ResultType;
         }
 
         /// <summary>


### PR DESCRIPTION
On iOS there is a system native prompt shown asking user wheter or not to logout.
Example: 
![sso_consent](https://user-images.githubusercontent.com/19332190/49233233-d4f28200-f3f5-11e8-8ddc-edf745adcec8.png)

It's explained in  #19 issue.
By returning `BrowserResultType` you can handle failed logout process correctly