### PR TITLE
Remove char \0 from response

### DIFF
--- a/src/Auth0.OidcClient.UWP/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.UWP/PlatformWebView.cs
@@ -100,7 +100,7 @@ namespace Auth0.OidcClient
                 return new BrowserResult
                 {
                     ResultType = BrowserResultType.Success,
-                    Response = wabResult.ResponseData
+                    Response = wabResult.ResponseData?.Replace("\0", string.Empty)
                 };
             }
 

--- a/src/Auth0.OidcClient.UWP/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.UWP/PlatformWebView.cs
@@ -100,6 +100,10 @@ namespace Auth0.OidcClient
                 return new BrowserResult
                 {
                     ResultType = BrowserResultType.Success,
+                    
+                    // Windows IoT Core adds a \0 char at the end of the ResponseData
+                    // when doing response_mode=form_post, so we remove it here
+                    // to avoid breaking the response processor.
                     Response = wabResult.ResponseData?.Replace("\0", string.Empty)
                 };
             }


### PR DESCRIPTION
Removes \0 ending (and possibly in other places?) from WebAuthenticationResult.ResponseData in Windows IoT Core. Fixes #28 