### PR TITLE
Wpf now has option to close Auth0 window

### DIFF
--- a/src/Auth0.OidcClient.WPF/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.WPF/PlatformWebView.cs
@@ -17,14 +17,17 @@ namespace Auth0.OidcClient
         /// </summary>
         /// <param name="windowFactory"> </param>
         /// <param name="shouldCloseWindow"> Determines whether the window closes or not after sucessful login</param>
-        
-        /// Example Usage:
+        /// <example> 
+        /// This sample shows how to call the <see cref="PlatformWebView(Func{Window}, bool)"/> constructor.
+        /// <code>
         /// Window ReturnWindow()
         /// {
         ///     return window; // your WPF applciation window where you want the login to pop up
         /// }
         /// Func<Window> windowFunc = ReturnWindow;
         /// PlatformWebView platformWebView = new PlatformWebView(windowFunc, shouldCloseWindow: false); // specify false if you want the window to remain open
+        /// </code>
+        /// </example>
         public PlatformWebView(Func<Window> windowFactory, bool shouldCloseWindow = true)
         {
             _windowFactory = windowFactory;

--- a/src/Auth0.OidcClient.WPF/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.WPF/PlatformWebView.cs
@@ -10,13 +10,15 @@ namespace Auth0.OidcClient
     public class PlatformWebView : IBrowser
     {
         private readonly Func<Window> _windowFactory;
+        private readonly bool _shouldCloseWindow;
 
-        public PlatformWebView(Func<Window> windowFactory)
+        public PlatformWebView(Func<Window> windowFactory, bool shouldCloseWindow = true)
         {
             _windowFactory = windowFactory;
+            _shouldCloseWindow = shouldCloseWindow;
         }
 
-        public PlatformWebView(string title = "Authenticating ...", int width = 1024, int height = 768)
+        public PlatformWebView(string title = "Authenticating ...", int width = 1024, int height = 768, bool shouldCloseWindow = true)
             : this(() => new Window
             {
                 Name = "WebAuthentication",
@@ -24,7 +26,10 @@ namespace Auth0.OidcClient
                 Width = width,
                 Height = height
             })
-        { }
+        {
+            _shouldCloseWindow = shouldCloseWindow;
+        }
+
         public async Task<BrowserResult> InvokeAsync(BrowserOptions options)
         {
             var window = _windowFactory.Invoke();
@@ -68,7 +73,10 @@ namespace Auth0.OidcClient
             }
             finally
             {
-                window.Close();
+                if (_shouldCloseWindow)
+                {
+                    window.Close();
+                }
             }
         }
     }

--- a/src/Auth0.OidcClient.WPF/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.WPF/PlatformWebView.cs
@@ -12,13 +12,26 @@ namespace Auth0.OidcClient
         private readonly Func<Window> _windowFactory;
         private readonly bool _shouldCloseWindow;
 
+        /// <summary>
+        /// Constructor which lets you pass in your WPF window and window closing property
+        /// </summary>
+        /// <param name="windowFactory"> </param>
+        /// <param name="shouldCloseWindow"> Determines whether the window closes or not after sucessgul login</param>
+        
+        /// Example Usage:
+        /// Window ReturnWindow()
+        /// {
+        ///     return window; // your WPF applciation window where you want the login to pop up
+        /// }
+        /// Func<Window> windowFunc = ReturnWindow;
+        /// PlatformWebView platformWebView = new PlatformWebView(windowFunc, shouldCloseWindow: false); // specify false if you want the window to remain open
         public PlatformWebView(Func<Window> windowFactory, bool shouldCloseWindow = true)
         {
             _windowFactory = windowFactory;
             _shouldCloseWindow = shouldCloseWindow;
         }
 
-        public PlatformWebView(string title = "Authenticating ...", int width = 1024, int height = 768, bool shouldCloseWindow = true)
+        public PlatformWebView(string title = "Authenticating ...", int width = 1024, int height = 768)
             : this(() => new Window
             {
                 Name = "WebAuthentication",
@@ -27,15 +40,17 @@ namespace Auth0.OidcClient
                 Height = height
             })
         {
-            _shouldCloseWindow = shouldCloseWindow;
+            _shouldCloseWindow = true;
         }
 
         public async Task<BrowserResult> InvokeAsync(BrowserOptions options)
         {
             var window = _windowFactory.Invoke();
+
             try
             {
                 var grid = new Grid();
+
                 window.Content = grid;
                 var browser = new WebBrowser();
 
@@ -68,6 +83,11 @@ namespace Auth0.OidcClient
                 browser.Navigate(options.StartUrl);
 
                 await signal.WaitAsync();
+
+                if (!_shouldCloseWindow)
+                {
+                    grid.Children.Clear();
+                }
 
                 return result;
             }

--- a/src/Auth0.OidcClient.WPF/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.WPF/PlatformWebView.cs
@@ -16,7 +16,7 @@ namespace Auth0.OidcClient
         /// Constructor which lets you pass in your WPF window and window closing property
         /// </summary>
         /// <param name="windowFactory"> </param>
-        /// <param name="shouldCloseWindow"> Determines whether the window closes or not after sucessgul login</param>
+        /// <param name="shouldCloseWindow"> Determines whether the window closes or not after sucessful login</param>
         
         /// Example Usage:
         /// Window ReturnWindow()

--- a/src/Auth0.OidcClient.WPF/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.WPF/PlatformWebView.cs
@@ -18,11 +18,11 @@ namespace Auth0.OidcClient
         /// <param name="windowFactory"> </param>
         /// <param name="shouldCloseWindow"> Determines whether the window closes or not after sucessful login</param>
         /// <example> 
-        /// This sample shows how to call the <see cref="PlatformWebView(Func{Window}, bool)"/> constructor.
+        /// This sample shows how to call the <see cref="PlatformWebView(Func&lt;Window&gt;, bool)"/> constructor.
         /// <code>
         /// Window ReturnWindow()
         /// {
-        ///     return window; // your WPF applciation window where you want the login to pop up
+        ///     return window; // your WPF application window where you want the login to pop up
         /// }
         /// Func<Window> windowFunc = ReturnWindow;
         /// PlatformWebView platformWebView = new PlatformWebView(windowFunc, shouldCloseWindow: false); // specify false if you want the window to remain open


### PR DESCRIPTION
#39

### Changes
For WPF applications, there is currently no way to make the Auth0 login flow part of the main application window. This is because the window passed into the constructor always closes the window after successful login.

This PR adds an optional boolean argument in the overloaded constructor which allows the user to specify whether the window needs to remain open or closed after successful login. This allows integration of the Auth0 window in the main WPF application window.


### Testing
This feature can be tested by passing in the main application window to Auth0 and logging in. Here is some sample code:
```
// Client side call for Auth0 login to show up in current active window
Window ReturnWindow()
{
    return Application.Current.Windows.OfType<Window>().SingleOrDefault(x => x.IsActive);
}
Func<Window> windowFunc = ReturnWindow;
PlatformWebView platformWebView = new PlatformWebView(windowFunc, shouldCloseWindow: false);
Auth0ClientOptions auth0ClientOptions = new Auth0ClientOptions
{
    Domain = tokenReqParams.Domain,
    ClientId = tokenReqParams.ClientId,
    RedirectUri = tokenReqParams.RedirectUrl,
    Browser = platformWebView
};

var auth0Client = new Auth0Client(auth0ClientOptions);
var loginResult = await auth0Client.LoginAsync();
```
After logging in successfully, your main application window will still be open.
