### PR TITLE
Added ASWebAuthenticationSession for iOS 12+. Improved error handling.

### DIFF
--- a/src/Auth0.OidcClient.Xamarin.iOS/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.Xamarin.iOS/PlatformWebView.cs
@@ -35,7 +35,7 @@ namespace Auth0.OidcClient
 			// with setting the task result
 			var tcs = new TaskCompletionSource<BrowserResult>();
 
-            // For iOS 11, we use the new SFAuthenticationSession
+            // For iOS 12, we use ASWebAuthenticationSession
             if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
             {
                 // create the authentication session
@@ -70,7 +70,7 @@ namespace Auth0.OidcClient
                 // launch authentication session
                 _asWebAuthenticationSession.Start();
             }
-            // For iOS 11, we use the new SFAuthenticationSession
+            // For iOS 11, we use SFAuthenticationSession
             else if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
 		    {
 		        // create the authentication session

--- a/src/Auth0.OidcClient.Xamarin.iOS/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.Xamarin.iOS/PlatformWebView.cs
@@ -8,156 +8,156 @@ using UIKit;
 
 namespace Auth0.OidcClient
 {
-    public class PlatformWebView : SFSafariViewControllerDelegate, IBrowser
-    {
-        private SFAuthenticationSession _sfAuthenticationSession;
-        private ASWebAuthenticationSession _asWebAuthenticationSession;
-        private SFSafariViewController _safari;
+	public class PlatformWebView : SFSafariViewControllerDelegate, IBrowser
+	{
+		private SFAuthenticationSession _sfAuthenticationSession;
+		private ASWebAuthenticationSession _asWebAuthenticationSession;
+		private SFSafariViewController _safari;
 
-        public override void DidFinish(SFSafariViewController controller)
-        {
-            ActivityMediator.Instance.Send("UserCancel");
-        }
+		public override void DidFinish(SFSafariViewController controller)
+		{
+			ActivityMediator.Instance.Send("UserCancel");
+		}
 
-        public Task<BrowserResult> InvokeAsync(BrowserOptions options)
-        {
-            if (string.IsNullOrWhiteSpace(options.StartUrl))
-            {
-                throw new ArgumentException("Missing StartUrl", nameof(options));
-            }
+		public Task<BrowserResult> InvokeAsync(BrowserOptions options)
+		{
+			if (string.IsNullOrWhiteSpace(options.StartUrl))
+			{
+				throw new ArgumentException("Missing StartUrl", nameof(options));
+			}
 
-            if (string.IsNullOrWhiteSpace(options.EndUrl))
-            {
-                throw new ArgumentException("Missing EndUrl", nameof(options));
-            }
+			if (string.IsNullOrWhiteSpace(options.EndUrl))
+			{
+				throw new ArgumentException("Missing EndUrl", nameof(options));
+			}
 
-            // must be able to wait for the authentication session to be finished to continue
-            // with setting the task result
-            var tcs = new TaskCompletionSource<BrowserResult>();
+			// must be able to wait for the authentication session to be finished to continue
+			// with setting the task result
+			var tcs = new TaskCompletionSource<BrowserResult>();
 
-            // For iOS 12, we use ASWebAuthenticationSession
-            if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
-            {
-                // create the authentication session
-                _asWebAuthenticationSession = new ASWebAuthenticationSession(
-                    new NSUrl(options.StartUrl),
-                    options.EndUrl,
-                    (callbackUrl, error) =>
-                    {
-                        var browserResult = new BrowserResult();
+			// For iOS 12, we use ASWebAuthenticationSession
+			if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
+			{
+				// create the authentication session
+				_asWebAuthenticationSession = new ASWebAuthenticationSession(
+					new NSUrl(options.StartUrl),
+					options.EndUrl,
+					(callbackUrl, error) =>
+					{
+						var browserResult = new BrowserResult();
 
-                        if (error != null)
-                        {
-                            if (error.Code == (long)ASWebAuthenticationSessionErrorCode.CanceledLogin)
-                                browserResult.ResultType = BrowserResultType.UserCancel;
-                            else
-                                browserResult.ResultType = BrowserResultType.UnknownError;
+						if (error != null)
+						{
+							if (error.Code == (long)ASWebAuthenticationSessionErrorCode.CanceledLogin)
+								browserResult.ResultType = BrowserResultType.UserCancel;
+							else
+								browserResult.ResultType = BrowserResultType.UnknownError;
 
-                            browserResult.Error = error.ToString();
+							browserResult.Error = error.ToString();
 
-                            tcs.SetResult(browserResult);
-                        }
-                        else
-                        {
-                            tcs.SetResult(new BrowserResult
-                            {
-                                ResultType = BrowserResultType.Success,
-                                Response = callbackUrl.AbsoluteString
-                            });
-                        }
-                    });
+							tcs.SetResult(browserResult);
+						}
+						else
+						{
+							tcs.SetResult(new BrowserResult
+							{
+								ResultType = BrowserResultType.Success,
+								Response = callbackUrl.AbsoluteString
+							});
+						}
+					});
 
-                // launch authentication session
-                _asWebAuthenticationSession.Start();
-            }
-            // For iOS 11, we use SFAuthenticationSession
-            else if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
-            {
-                // create the authentication session
-                _sfAuthenticationSession = new SFAuthenticationSession(
-                    new NSUrl(options.StartUrl),
-                    options.EndUrl,
-                    (callbackUrl, error) =>
-                    {
-                        var browserResult = new BrowserResult();
+				// launch authentication session
+				_asWebAuthenticationSession.Start();
+			}
+			// For iOS 11, we use SFAuthenticationSession
+			else if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
+			{
+				// create the authentication session
+				_sfAuthenticationSession = new SFAuthenticationSession(
+					new NSUrl(options.StartUrl),
+					options.EndUrl,
+					(callbackUrl, error) =>
+					{
+						var browserResult = new BrowserResult();
 
-                        if (error != null)
-                        {
-                            if (error.Code == (long)SFAuthenticationError.CanceledLogin)
-                                browserResult.ResultType = BrowserResultType.UserCancel;
-                            else
-                                browserResult.ResultType = BrowserResultType.UnknownError;
+						if (error != null)
+						{
+							if (error.Code == (long)SFAuthenticationError.CanceledLogin)
+								browserResult.ResultType = BrowserResultType.UserCancel;
+							else
+								browserResult.ResultType = BrowserResultType.UnknownError;
 
-                            browserResult.Error = error.ToString();
+							browserResult.Error = error.ToString();
 
-                            tcs.SetResult(browserResult);
-                        }
-                        else
-                        {
-                            tcs.SetResult(new BrowserResult
-                            {
-                                ResultType = BrowserResultType.Success,
-                                Response = callbackUrl.AbsoluteString
-                            });
-                        }
-                    });
+							tcs.SetResult(browserResult);
+						}
+						else
+						{
+							tcs.SetResult(new BrowserResult
+							{
+								ResultType = BrowserResultType.Success,
+								Response = callbackUrl.AbsoluteString
+							});
+						}
+					});
 
-                // launch authentication session
-                _sfAuthenticationSession.Start();
-            }
-            else // For pre-iOS 11, we use a normal SFSafariViewController
-            {
-                // create Safari controller
-                _safari = new SFSafariViewController(new NSUrl(options.StartUrl))
-                {
-                    Delegate = this
-                };
+				// launch authentication session
+				_sfAuthenticationSession.Start();
+			}
+			else // For pre-iOS 11, we use a normal SFSafariViewController
+			{
+				// create Safari controller
+				_safari = new SFSafariViewController(new NSUrl(options.StartUrl))
+				{
+					Delegate = this
+				};
 
-                ActivityMediator.MessageReceivedEventHandler callback = null;
-                callback = async (response) =>
-                {
-                    // remove handler
-                    ActivityMediator.Instance.ActivityMessageReceived -= callback;
+				ActivityMediator.MessageReceivedEventHandler callback = null;
+				callback = async (response) =>
+				{
+					// remove handler
+					ActivityMediator.Instance.ActivityMessageReceived -= callback;
 
-                    if (response == "UserCancel")
-                    {
-                        tcs.SetResult(new BrowserResult
-                        {
-                            ResultType = BrowserResultType.UserCancel
-                        });
-                    }
-                    else
-                    {
-                        // Close Safari
-                        await _safari.DismissViewControllerAsync(true);
+					if (response == "UserCancel")
+					{
+						tcs.SetResult(new BrowserResult
+						{
+							ResultType = BrowserResultType.UserCancel
+						});
+					}
+					else
+					{
+						// Close Safari
+						await _safari.DismissViewControllerAsync(true);
 
-                        // set result
-                        tcs.SetResult(new BrowserResult
-                        {
-                            Response = response,
-                            ResultType = BrowserResultType.Success
-                        });
-                    }
-                };
+						// set result
+						tcs.SetResult(new BrowserResult
+						{
+							Response = response,
+							ResultType = BrowserResultType.Success
+						});
+					}
+				};
 
-                // attach handler
-                ActivityMediator.Instance.ActivityMessageReceived += callback;
+				// attach handler
+				ActivityMediator.Instance.ActivityMessageReceived += callback;
 
-                // https://forums.xamarin.com/discussion/24689/how-to-acces-the-current-view-uiviewcontroller-from-an-external-service
-                var window = UIApplication.SharedApplication.KeyWindow;
-                var vc = window.RootViewController;
-                while (vc.PresentedViewController != null)
-                {
-                    vc = vc.PresentedViewController;
-                }
+				// https://forums.xamarin.com/discussion/24689/how-to-acces-the-current-view-uiviewcontroller-from-an-external-service
+				var window = UIApplication.SharedApplication.KeyWindow;
+				var vc = window.RootViewController;
+				while (vc.PresentedViewController != null)
+				{
+					vc = vc.PresentedViewController;
+				}
 
-                // launch Safari
-                vc.PresentViewController(_safari, true, null);
-            }
+				// launch Safari
+				vc.PresentViewController(_safari, true, null);
+			}
 
-            // Result for this task will be set in the authentication session
-            // completion handler
-            return tcs.Task;
-        }
-    }
+			// Result for this task will be set in the authentication session
+			// completion handler
+			return tcs.Task;
+		}
+	}
 }

--- a/src/Auth0.OidcClient.Xamarin.iOS/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.Xamarin.iOS/PlatformWebView.cs
@@ -8,156 +8,156 @@ using UIKit;
 
 namespace Auth0.OidcClient
 {
-	public class PlatformWebView : SFSafariViewControllerDelegate, IBrowser
-	{
-		private SFAuthenticationSession _sfAuthenticationSession;
-		private ASWebAuthenticationSession _asWebAuthenticationSession;
-		private SFSafariViewController _safari;
+    public class PlatformWebView : SFSafariViewControllerDelegate, IBrowser
+    {
+        private SFAuthenticationSession _sfAuthenticationSession;
+        private ASWebAuthenticationSession _asWebAuthenticationSession;
+        private SFSafariViewController _safari;
 
-		public override void DidFinish(SFSafariViewController controller)
-		{
-			ActivityMediator.Instance.Send("UserCancel");
-		}
+        public override void DidFinish(SFSafariViewController controller)
+        {
+            ActivityMediator.Instance.Send("UserCancel");
+        }
 
-		public Task<BrowserResult> InvokeAsync(BrowserOptions options)
-		{
-			if (string.IsNullOrWhiteSpace(options.StartUrl))
-			{
-				throw new ArgumentException("Missing StartUrl", nameof(options));
-			}
+        public Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(options.StartUrl))
+            {
+                throw new ArgumentException("Missing StartUrl", nameof(options));
+            }
 
-			if (string.IsNullOrWhiteSpace(options.EndUrl))
-			{
-				throw new ArgumentException("Missing EndUrl", nameof(options));
-			}
+            if (string.IsNullOrWhiteSpace(options.EndUrl))
+            {
+                throw new ArgumentException("Missing EndUrl", nameof(options));
+            }
 
-			// must be able to wait for the authentication session to be finished to continue
-			// with setting the task result
-			var tcs = new TaskCompletionSource<BrowserResult>();
+            // must be able to wait for the authentication session to be finished to continue
+            // with setting the task result
+            var tcs = new TaskCompletionSource<BrowserResult>();
 
-			// For iOS 12, we use ASWebAuthenticationSession
-			if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
-			{
-				// create the authentication session
-				_asWebAuthenticationSession = new ASWebAuthenticationSession(
-					new NSUrl(options.StartUrl),
-					options.EndUrl,
-					(callbackUrl, error) =>
-					{
-						var browserResult = new BrowserResult();
+            // For iOS 12, we use ASWebAuthenticationSession
+            if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
+            {
+                // create the authentication session
+                _asWebAuthenticationSession = new ASWebAuthenticationSession(
+                    new NSUrl(options.StartUrl),
+                    options.EndUrl,
+                    (callbackUrl, error) =>
+                    {
+                        var browserResult = new BrowserResult();
 
-						if (error != null)
-						{
-							if (error.Code == (long)ASWebAuthenticationSessionErrorCode.CanceledLogin)
-								browserResult.ResultType = BrowserResultType.UserCancel;
-							else
-								browserResult.ResultType = BrowserResultType.UnknownError;
+                        if (error != null)
+                        {
+                            if (error.Code == (long)ASWebAuthenticationSessionErrorCode.CanceledLogin)
+                                browserResult.ResultType = BrowserResultType.UserCancel;
+                            else
+                                browserResult.ResultType = BrowserResultType.UnknownError;
 
-							browserResult.Error = error.ToString();
+                            browserResult.Error = error.ToString();
 
-							tcs.SetResult(browserResult);
-						}
-						else
-						{
-							tcs.SetResult(new BrowserResult
-							{
-								ResultType = BrowserResultType.Success,
-								Response = callbackUrl.AbsoluteString
-							});
-						}
-					});
+                            tcs.SetResult(browserResult);
+                        }
+                        else
+                        {
+                            tcs.SetResult(new BrowserResult
+                            {
+                                ResultType = BrowserResultType.Success,
+                                Response = callbackUrl.AbsoluteString
+                            });
+                        }
+                    });
 
-				// launch authentication session
-				_asWebAuthenticationSession.Start();
-			}
-			// For iOS 11, we use SFAuthenticationSession
-			else if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
-			{
-				// create the authentication session
-				_sfAuthenticationSession = new SFAuthenticationSession(
-					new NSUrl(options.StartUrl),
-					options.EndUrl,
-					(callbackUrl, error) =>
-					{
-						var browserResult = new BrowserResult();
+                // launch authentication session
+                _asWebAuthenticationSession.Start();
+            }
+            // For iOS 11, we use SFAuthenticationSession
+            else if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
+            {
+                // create the authentication session
+                _sfAuthenticationSession = new SFAuthenticationSession(
+                    new NSUrl(options.StartUrl),
+                    options.EndUrl,
+                    (callbackUrl, error) =>
+                    {
+                        var browserResult = new BrowserResult();
 
-						if (error != null)
-						{
-							if (error.Code == (long)SFAuthenticationError.CanceledLogin)
-								browserResult.ResultType = BrowserResultType.UserCancel;
-							else
-								browserResult.ResultType = BrowserResultType.UnknownError;
+                        if (error != null)
+                        {
+                            if (error.Code == (long)SFAuthenticationError.CanceledLogin)
+                                browserResult.ResultType = BrowserResultType.UserCancel;
+                            else
+                                browserResult.ResultType = BrowserResultType.UnknownError;
 
-							browserResult.Error = error.ToString();
+                            browserResult.Error = error.ToString();
 
-							tcs.SetResult(browserResult);
-						}
-						else
-						{
-							tcs.SetResult(new BrowserResult
-							{
-								ResultType = BrowserResultType.Success,
-								Response = callbackUrl.AbsoluteString
-							});
-						}
-					});
+                            tcs.SetResult(browserResult);
+                        }
+                        else
+                        {
+                            tcs.SetResult(new BrowserResult
+                            {
+                                ResultType = BrowserResultType.Success,
+                                Response = callbackUrl.AbsoluteString
+                            });
+                        }
+                    });
 
-				// launch authentication session
-				_sfAuthenticationSession.Start();
-			}
-			else // For pre-iOS 11, we use a normal SFSafariViewController
-			{
-				// create Safari controller
-				_safari = new SFSafariViewController(new NSUrl(options.StartUrl))
-				{
-					Delegate = this
-				};
+                // launch authentication session
+                _sfAuthenticationSession.Start();
+            }
+            else // For pre-iOS 11, we use a normal SFSafariViewController
+            {
+                // create Safari controller
+                _safari = new SFSafariViewController(new NSUrl(options.StartUrl))
+                {
+                    Delegate = this
+                };
 
-				ActivityMediator.MessageReceivedEventHandler callback = null;
-				callback = async (response) =>
-				{
-					// remove handler
-					ActivityMediator.Instance.ActivityMessageReceived -= callback;
+                ActivityMediator.MessageReceivedEventHandler callback = null;
+                callback = async (response) =>
+                {
+                    // remove handler
+                    ActivityMediator.Instance.ActivityMessageReceived -= callback;
 
-					if (response == "UserCancel")
-					{
-						tcs.SetResult(new BrowserResult
-						{
-							ResultType = BrowserResultType.UserCancel
-						});
-					}
-					else
-					{
-						// Close Safari
-						await _safari.DismissViewControllerAsync(true);
+                    if (response == "UserCancel")
+                    {
+                        tcs.SetResult(new BrowserResult
+                        {
+                            ResultType = BrowserResultType.UserCancel
+                        });
+                    }
+                    else
+                    {
+                        // Close Safari
+                        await _safari.DismissViewControllerAsync(true);
 
-						// set result
-						tcs.SetResult(new BrowserResult
-						{
-							Response = response,
-							ResultType = BrowserResultType.Success
-						});
-					}
-				};
+                        // set result
+                        tcs.SetResult(new BrowserResult
+                        {
+                            Response = response,
+                            ResultType = BrowserResultType.Success
+                        });
+                    }
+                };
 
-				// attach handler
-				ActivityMediator.Instance.ActivityMessageReceived += callback;
+                // attach handler
+                ActivityMediator.Instance.ActivityMessageReceived += callback;
 
-				// https://forums.xamarin.com/discussion/24689/how-to-acces-the-current-view-uiviewcontroller-from-an-external-service
-				var window = UIApplication.SharedApplication.KeyWindow;
-				var vc = window.RootViewController;
-				while (vc.PresentedViewController != null)
-				{
-					vc = vc.PresentedViewController;
-				}
+                // https://forums.xamarin.com/discussion/24689/how-to-acces-the-current-view-uiviewcontroller-from-an-external-service
+                var window = UIApplication.SharedApplication.KeyWindow;
+                var vc = window.RootViewController;
+                while (vc.PresentedViewController != null)
+                {
+                    vc = vc.PresentedViewController;
+                }
 
-				// launch Safari
-				vc.PresentViewController(_safari, true, null);
-			}
+                // launch Safari
+                vc.PresentViewController(_safari, true, null);
+            }
 
-			// Result for this task will be set in the authentication session
-			// completion handler
-			return tcs.Task;
-		}
-	}
+            // Result for this task will be set in the authentication session
+            // completion handler
+            return tcs.Task;
+        }
+    }
 }


### PR DESCRIPTION
### Changes

Summary:
Added ASWebAuthenticationSession for iOS 12+. Improved error handling to explicitly deal with user cancellation.

- Added ASWebAuthenticationSession support, which supplants SFAuthenticationSession (deprecated in iOS 12).

- Improved error handling for both the ASWebAuthenticationSession and SFAuthenticationSession scenarios to explicitly look for the user-cancelled error code, and update the BrowserResult appropriately if found. Otherwise BrowserResult type is UnknownError. ASWebAuthenticationSession and SFAuthenticationSession each only define one known type of error: `ASWebAuthenticationSessionErrorCode.CanceledLogin` and `SFAuthenticationError.CanceledLogin`, respectively.

### References

Rationale for ASWebAuthenticationSession:
https://developer.apple.com/documentation/safariservices/sfauthenticationsession

### Testing

The API surfaces of SFAuthenticationSession and ASWebAuthenticationSession are identical.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
