### PR TITLE
Switch to auth0 test tenant

### DIFF
--- a/test/UwpTestApp/MainPage.xaml.cs
+++ b/test/UwpTestApp/MainPage.xaml.cs
@@ -20,8 +20,8 @@ namespace UwpTestApp
 
             _auth0Client = new Auth0Client(new Auth0ClientOptions
             {
-                Domain = "jerrie.auth0.com",
-                ClientId = "vV9twaySQzfGesS9Qs6gOgqDsYDdgoKE"
+                Domain = "auth0-dotnet-integration-tests.auth0.com",
+                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2"
             });
         }
 

--- a/test/UwpTestApp/Package.appxmanifest
+++ b/test/UwpTestApp/Package.appxmanifest
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="e2787c3f-97ee-4dbd-b932-f3034873dd17" Publisher="CN=jerriepelser" Version="1.0.0.0" />
+  <Identity Name="e2787c3f-97ee-4dbd-b932-f3034873dd17" Publisher="CN=Auth0" Version="1.0.0.0" />
   <mp:PhoneIdentity PhoneProductId="e2787c3f-97ee-4dbd-b932-f3034873dd17" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>UwpSampleApp</DisplayName>
-    <PublisherDisplayName>jerri</PublisherDisplayName>
+    <PublisherDisplayName>Auth0</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
   <Dependencies>

--- a/test/WindowsFormsTestApp/Form1.cs
+++ b/test/WindowsFormsTestApp/Form1.cs
@@ -15,8 +15,8 @@ namespace WindowsFormsTestApp
 
             _auth0Client = new Auth0Client(new Auth0ClientOptions
             {
-                Domain = "jerrie.auth0.com",
-                ClientId = "vV9twaySQzfGesS9Qs6gOgqDsYDdgoKE"
+                Domain = "auth0-dotnet-integration-tests.auth0.com",
+                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2"
             });
         }
 

--- a/test/WpfSystemBrowserTestApp/MainWindow.xaml.cs
+++ b/test/WpfSystemBrowserTestApp/MainWindow.xaml.cs
@@ -17,8 +17,8 @@ namespace WpfSystemBrowserTestApp
 
             _auth0Client = new Auth0Client(new Auth0ClientOptions
             {
-                Domain = "jerrie.auth0.com",
-                ClientId = "vV9twaySQzfGesS9Qs6gOgqDsYDdgoKE",
+                Domain = "auth0-dotnet-integration-tests.auth0.com",
+                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2",
                 Scope = "openid profile email",
                 Browser = new SystemWebBrowser(),
                 RedirectUri = "http://127.0.0.1:7890/",

--- a/test/WpfTestApp/MainWindow.xaml.cs
+++ b/test/WpfTestApp/MainWindow.xaml.cs
@@ -17,8 +17,8 @@ namespace WpfTestApp
 
             _auth0Client = new Auth0Client(new Auth0ClientOptions
             {
-                Domain = "jerrie.auth0.com",
-                ClientId = "vV9twaySQzfGesS9Qs6gOgqDsYDdgoKE",
+                Domain = "auth0-dotnet-integration-tests.auth0.com",
+                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2",
                 Scope = "openid profile email"
             });
         }

--- a/test/XamarinAndroidTestApp/Resources/values/Strings.xml
+++ b/test/XamarinAndroidTestApp/Resources/values/Strings.xml
@@ -4,6 +4,6 @@
   <string name="Login">Login</string>
   <string name="Logout">Logout</string>
   <string name="ApplicationName">XamarinAndroidTestApp</string>
-  <string name="auth0_client_id">vV9twaySQzfGesS9Qs6gOgqDsYDdgoKE</string>
-  <string name="auth0_domain">jerrie.auth0.com</string>
+  <string name="auth0_client_id">qmss9A66stPWTOXjR6X1OeA0DLadoNP2</string>
+  <string name="auth0_domain">auth0-dotnet-integration-tests.auth0.com</string>
 </resources>


### PR DESCRIPTION
The previous tenant used for testing has been removed. This points to the new one we also use for auth0.net.