### PR TITLE
Provide a PlatformWebView for back-compat that defaults to best.

### DIFF
--- a/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
+++ b/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
@@ -51,6 +51,7 @@
     <Compile Include="Auth0Client.cs" />
     <Compile Include="Auth0ClientActivity.cs" />
     <Compile Include="ChromeCustomTabsWebView.cs" />
+    <Compile Include="PlatformWebView.cs" />
     <Compile Include="SystemBrowserWebView.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Auth0.OidcClient.Android/Auth0Client.cs
+++ b/src/Auth0.OidcClient.Android/Auth0Client.cs
@@ -15,7 +15,7 @@ namespace Auth0.OidcClient
         public Auth0Client(Auth0ClientOptions options)
             : base(options, "xamarin-android")
         {
-            options.Browser = options.Browser ?? new ChromeCustomTabsWebView();
+            options.Browser = options.Browser ?? new PlatformWebView();
             var callbackUrl = $"{Context.PackageName}://{options.Domain}/android/{Context.PackageName}/callback".ToLower();
             options.RedirectUri = callbackUrl;
             options.PostLogoutRedirectUri = options.PostLogoutRedirectUri ?? callbackUrl;

--- a/src/Auth0.OidcClient.Android/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.Android/PlatformWebView.cs
@@ -1,0 +1,10 @@
+﻿namespace Auth0.OidcClient
+{
+    /// <summary>
+    /// PlatformWebView offers the best platform-specific web view implementation
+    /// at a given time. On Android that is the Chrome Custom Tabs at this time.
+    /// </summary>
+    public class PlatformWebView : ChromeCustomTabsWebView
+    {
+    }
+}


### PR DESCRIPTION
In order to be backward compatible with existing Android code we need a PlatformWebView class.  This class should always default to the best-practice implementation on a platform.  Today that is the ChromeCustomTab implementation.