### PR TITLE
Split iOS Browser integrations to allow user to specify

### DIFF
--- a/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
@@ -1,0 +1,48 @@
+﻿using AuthenticationServices;
+using Foundation;
+using IdentityModel.OidcClient.Browser;
+using System.Threading.Tasks;
+
+namespace Auth0.OidcClient
+{
+    /// <summary>
+    /// Implements the Browser interface using ASWebAuthenticationSession for support on iOS 12+.
+    /// </summary>
+    public class ASWebAuthenticationSessionBrowser : IOSBrowserBase
+    {
+        protected override Task<BrowserResult> Launch(BrowserOptions options)
+        {
+            return Launch(options);
+        }
+
+        internal static Task<BrowserResult> Start(BrowserOptions options)
+        {
+            var tcs = new TaskCompletionSource<BrowserResult>();
+
+            ASWebAuthenticationSession asWebAuthenticationSession = null;
+            asWebAuthenticationSession = new ASWebAuthenticationSession(
+                new NSUrl(options.StartUrl),
+                options.EndUrl,
+                (callbackUrl, error) =>
+                {
+                    tcs.SetResult(CreateBrowserResult(callbackUrl, error));
+                    asWebAuthenticationSession.Dispose();
+                });
+
+            asWebAuthenticationSession.Start();
+
+            return tcs.Task;
+        }
+
+        private static BrowserResult CreateBrowserResult(NSUrl callbackUrl, NSError error)
+        {
+            if (error == null)
+                return Success(callbackUrl.AbsoluteString);
+
+            if (error.Code == (long)ASWebAuthenticationSessionErrorCode.CanceledLogin)
+                return Canceled();
+
+            return UnknownError(error.ToString());
+        }
+    }
+}

--- a/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
+++ b/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
@@ -44,7 +44,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="ActivityMediator.cs" />
+    <Compile Include="IOSBrowserBase.cs" />
     <Compile Include="Auth0Client.cs" />
+    <Compile Include="ASWebAuthenticationSessionBrowser.cs" />
+    <Compile Include="SFAuthenticationSessionBrowser.cs" />
+    <Compile Include="SFSafariViewControllerBrowser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PlatformWebView.cs" />
   </ItemGroup>

--- a/src/Auth0.OidcClient.iOS/Auth0Client.cs
+++ b/src/Auth0.OidcClient.iOS/Auth0Client.cs
@@ -16,7 +16,9 @@ namespace Auth0.OidcClient
             : base(options, "xamarin-ios")
         {
             options.Browser = options.Browser ?? new PlatformWebView();
-            options.RedirectUri = options.RedirectUri ?? $"{MainBundle.BundleIdentifier}://{options.Domain}/ios/{MainBundle.BundleIdentifier}/callback";
+            var callbackUrl = $"{MainBundle.BundleIdentifier}://{options.Domain}/ios/{MainBundle.BundleIdentifier}/callback";
+            options.RedirectUri = callbackUrl;
+            options.PostLogoutRedirectUri = options.PostLogoutRedirectUri ?? callbackUrl;
         }
     }
 }

--- a/src/Auth0.OidcClient.iOS/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.iOS/PlatformWebView.cs
@@ -1,163 +1,26 @@
-﻿using System;
+﻿using IdentityModel.OidcClient.Browser;
 using System.Threading.Tasks;
-using AuthenticationServices;
-using Foundation;
-using IdentityModel.OidcClient.Browser;
-using SafariServices;
 using UIKit;
 
 namespace Auth0.OidcClient
 {
-    public class PlatformWebView : SFSafariViewControllerDelegate, IBrowser
+    /// <summary>
+    /// Implements the Browser interface using the best available option for the current iOS version.
+    /// </summary>
+    public class PlatformWebView : IOSBrowserBase
     {
-        private SFAuthenticationSession _sfWebAuthenticationSession;
-        private ASWebAuthenticationSession _asWebAuthenticationSession;
-        private SFSafariViewController _safari;
-
-        public override void DidFinish(SFSafariViewController controller)
+        protected override Task<BrowserResult> Launch(BrowserOptions options)
         {
-            ActivityMediator.Instance.Send("UserCancel");
-        }
-
-        public Task<BrowserResult> InvokeAsync(BrowserOptions options)
-        {
-            if (string.IsNullOrWhiteSpace(options.StartUrl))
-            {
-                throw new ArgumentException("Missing StartUrl", nameof(options));
-            }
-
-            if (string.IsNullOrWhiteSpace(options.EndUrl))
-            {
-                throw new ArgumentException("Missing EndUrl", nameof(options));
-            }
-
-            // must be able to wait for the authentication session to be finished to continue
-            // with setting the task result
-            var tcs = new TaskCompletionSource<BrowserResult>();
-
-            // For iOS 12, we use ASWebAuthenticationSession
+            // For iOS 12+ use ASWebAuthenticationSession
             if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))
-            {
-                // create the authentication session
-                _asWebAuthenticationSession = new ASWebAuthenticationSession(
-                    new NSUrl(options.StartUrl),
-                    options.EndUrl,
-                    (callbackUrl, error) =>
-                    {
-                        var browserResult = new BrowserResult();
+                return ASWebAuthenticationSessionBrowser.Start(options);
 
-                        if (error != null)
-                        {
-                            if (error.Code == (long)ASWebAuthenticationSessionErrorCode.CanceledLogin)
-                                browserResult.ResultType = BrowserResultType.UserCancel;
-                            else
-                                browserResult.ResultType = BrowserResultType.UnknownError;
+            // For iOS 11 use SFAuthenticationSession
+            if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
+                return SFAuthenticationSessionBrowser.Start(options);
 
-                            browserResult.Error = error.ToString();
-
-                            tcs.SetResult(browserResult);
-                        }
-                        else
-                        {
-                            tcs.SetResult(new BrowserResult
-                            {
-                                ResultType = BrowserResultType.Success,
-                                Response = callbackUrl.AbsoluteString
-                            });
-                        }
-                    });
-
-                // launch authentication session
-                _asWebAuthenticationSession.Start();
-            }
-            // For iOS 11, we use SFAuthenticationSession
-            else if (UIDevice.CurrentDevice.CheckSystemVersion(11, 0))
-            {
-                // create the authentication session
-                _sfWebAuthenticationSession = new SFAuthenticationSession(
-                    new NSUrl(options.StartUrl),
-                    options.EndUrl,
-                    (callbackUrl, error) =>
-                    {
-                        var browserResult = new BrowserResult();
-
-                        if (error != null)
-                        {
-                            if (error.Code == (long)SFAuthenticationError.CanceledLogin)
-                                browserResult.ResultType = BrowserResultType.UserCancel;
-                            else
-                                browserResult.ResultType = BrowserResultType.UnknownError;
-
-                            browserResult.Error = error.ToString();
-
-                            tcs.SetResult(browserResult);
-                        }
-                        else
-                        {
-                            tcs.SetResult(new BrowserResult
-                            {
-                                ResultType = BrowserResultType.Success,
-                                Response = callbackUrl.AbsoluteString
-                            });
-                        }
-                    });
-
-                // launch authentication session
-                _sfWebAuthenticationSession.Start();
-            }
-            else // For pre-iOS 11, we use a normal SFSafariViewController
-            {
-                // create Safari controller
-                _safari = new SFSafariViewController(new NSUrl(options.StartUrl))
-                {
-                    Delegate = this
-                };
-
-                ActivityMediator.MessageReceivedEventHandler callback = null;
-                callback = async (response) =>
-                {
-                    // remove handler
-                    ActivityMediator.Instance.ActivityMessageReceived -= callback;
-
-                    if (response == "UserCancel")
-                    {
-                        tcs.SetResult(new BrowserResult
-                        {
-                            ResultType = BrowserResultType.UserCancel
-                        });
-                    }
-                    else
-                    {
-                        // Close Safari
-                        await _safari.DismissViewControllerAsync(true);
-
-                        // set result
-                        tcs.SetResult(new BrowserResult
-                        {
-                            Response = response,
-                            ResultType = BrowserResultType.Success
-                        });
-                    }
-                };
-
-                // attach handler
-                ActivityMediator.Instance.ActivityMessageReceived += callback;
-
-                // https://forums.xamarin.com/discussion/24689/how-to-acces-the-current-view-uiviewcontroller-from-an-external-service
-                var window = UIApplication.SharedApplication.KeyWindow;
-                var vc = window.RootViewController;
-                while (vc.PresentedViewController != null)
-                {
-                    vc = vc.PresentedViewController;
-                }
-
-                // launch Safari
-                vc.PresentViewController(_safari, true, null);
-            }
-
-            // Result for this task will be set in the authentication session
-            // completion handler
-            return tcs.Task;
+            // For iOS 10 and earlier use SFSafariViewController
+            return SFSafariViewControllerBrowser.Start(options);
         }
     }
 }

--- a/src/Auth0.OidcClient.iOS/SFAuthenticationSessionBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/SFAuthenticationSessionBrowser.cs
@@ -1,0 +1,48 @@
+﻿using Foundation;
+using IdentityModel.OidcClient.Browser;
+using SafariServices;
+using System.Threading.Tasks;
+
+namespace Auth0.OidcClient
+{
+    /// <summary>
+    /// Implements the Browser interface using SFAuthenticationSession for support on iOS 11.
+    /// </summary>
+    public class SFAuthenticationSessionBrowser : IOSBrowserBase
+    {
+        protected override Task<BrowserResult> Launch(BrowserOptions options)
+        {
+            return Start(options);
+        }
+
+        internal static Task<BrowserResult> Start(BrowserOptions options)
+        {
+            var tcs = new TaskCompletionSource<BrowserResult>();
+
+            SFAuthenticationSession sfWebAuthenticationSession = null;
+            sfWebAuthenticationSession = new SFAuthenticationSession(
+                new NSUrl(options.StartUrl),
+                options.EndUrl,
+                (callbackUrl, error) =>
+                {
+                    tcs.SetResult(CreateBrowserResult(callbackUrl, error));
+                    sfWebAuthenticationSession.Dispose();
+                });
+
+            sfWebAuthenticationSession.Start();
+
+            return tcs.Task;
+        }
+
+        private static BrowserResult CreateBrowserResult(NSUrl callbackUrl, NSError error)
+        {
+            if (error == null)
+                return Success(callbackUrl.AbsoluteString);
+
+            if (error.Code == (long)SFAuthenticationError.CanceledLogin)
+                return Canceled();
+
+            return UnknownError(error.ToString());
+        }
+    }
+}

--- a/src/Auth0.OidcClient.iOS/SFSafariViewControllerBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/SFSafariViewControllerBrowser.cs
@@ -1,0 +1,69 @@
+﻿using Foundation;
+using IdentityModel.OidcClient.Browser;
+using SafariServices;
+using System.Threading.Tasks;
+using UIKit;
+
+namespace Auth0.OidcClient
+{
+    /// <summary>
+    /// Implements the Browser interface using SFSafariViewController for support on iOS 10 and earlier.
+    /// </summary>
+    public class SFSafariViewControllerBrowser : IOSBrowserBase
+    {
+        protected override Task<BrowserResult> Launch(BrowserOptions options)
+        {
+            return Start(options);
+        }
+
+        internal static Task<BrowserResult> Start(BrowserOptions options)
+        {
+            var tcs = new TaskCompletionSource<BrowserResult>();
+
+            // Create Safari controller
+            var safari = new SFSafariViewController(new NSUrl(options.StartUrl))
+            {
+                Delegate = new SafariViewControllerDelegate()
+            };
+
+            async void Callback(string response)
+            {
+                ActivityMediator.Instance.ActivityMessageReceived -= Callback;
+
+                if (response == "UserCancel")
+                {
+                    tcs.SetResult(Canceled());
+                }
+                else
+                {
+                    await safari.DismissViewControllerAsync(true); // Close Safari
+                    safari.Dispose();
+                    tcs.SetResult(Success(response));
+                }
+            }
+
+            ActivityMediator.Instance.ActivityMessageReceived += Callback;
+
+            // Launch Safari
+            FindRootController().PresentViewController(safari, true, null);
+
+            return tcs.Task;
+        }
+
+        private static UIViewController FindRootController()
+        {
+            var vc = UIApplication.SharedApplication.KeyWindow.RootViewController;
+            while (vc.PresentedViewController != null)
+                vc = vc.PresentedViewController;
+            return vc;
+        }
+
+        class SafariViewControllerDelegate : SFSafariViewControllerDelegate
+        {
+            public override void DidFinish(SFSafariViewController controller)
+            {
+                ActivityMediator.Instance.Send("UserCancel");
+            }
+        }
+    }
+}

--- a/src/Auth0.OidcClient.iOS/iOSBrowserBase.cs
+++ b/src/Auth0.OidcClient.iOS/iOSBrowserBase.cs
@@ -1,0 +1,48 @@
+﻿using IdentityModel.OidcClient.Browser;
+using System;
+using System.Threading.Tasks;
+
+namespace Auth0.OidcClient
+{
+    public abstract class IOSBrowserBase : IBrowser
+    {
+        public Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        {
+            if (string.IsNullOrWhiteSpace(options.StartUrl))
+                throw new ArgumentException("Missing StartUrl", nameof(options));
+
+            if (string.IsNullOrWhiteSpace(options.EndUrl))
+                throw new ArgumentException("Missing EndUrl", nameof(options));
+
+            return Launch(options);
+        }
+
+        protected abstract Task<BrowserResult> Launch(BrowserOptions options);
+
+        protected static BrowserResult Canceled()
+        {
+            return new BrowserResult
+            {
+                ResultType = BrowserResultType.UserCancel
+            };
+        }
+
+        protected static BrowserResult UnknownError(string error)
+        {
+            return new BrowserResult
+            {
+                ResultType = BrowserResultType.UnknownError,
+                Error = error
+            };
+        }
+
+        protected static BrowserResult Success(string response)
+        {
+            return new BrowserResult
+            {
+                Response = response,
+                ResultType = BrowserResultType.Success
+            };
+        }
+    }
+}


### PR DESCRIPTION
There are three ways of firing off a secure browser for authentication on iOS today:

- ASWebAuthenticationSession (recommended and supported for iOS 12+)
- SFAuthenticationSession (supported on iOS 11 only)
- SFSafariViewController (recommended for iOS 10 and lower, supported on all)

Right now we dynamically figure out at run-time which to use however there are some scenarios where you might want to use an alternative.

By splitting these out you can now specify one directly in your configuration options, e.g.

```csharp
var options = new Auth0ClientOptions {
    Domain = "auth0-dotnet-integration-tests.auth0.com",
    ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2",
    Scope = "openid profile email",
    Browser = new SFSafariViewControllerBrowser()
});
````

Additionally this PR:

- defaults the logout redirect url so it works automatically.
- actually disposes the iOS classes once they have done their work.