### PR TITLE
Rename *WebView to *Browser on Android for consistency

### DIFF
--- a/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
+++ b/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
@@ -50,9 +50,9 @@
     <Compile Include="AndroidWebViewBase.cs" />
     <Compile Include="Auth0Client.cs" />
     <Compile Include="Auth0ClientActivity.cs" />
-    <Compile Include="ChromeCustomTabsWebView.cs" />
+    <Compile Include="ChromeCustomTabsBrowser.cs" />
     <Compile Include="PlatformWebView.cs" />
-    <Compile Include="SystemBrowserWebView.cs" />
+    <Compile Include="SystemBrowser.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/Auth0.OidcClient.Android/ChromeCustomTabsBrowser.cs
+++ b/src/Auth0.OidcClient.Android/ChromeCustomTabsBrowser.cs
@@ -4,7 +4,7 @@ using Android.Support.CustomTabs;
 
 namespace Auth0.OidcClient
 {
-    public class ChromeCustomTabsWebView : AndroidWebViewBase
+    public class ChromeCustomTabsBrowser : AndroidWebViewBase
     {
         protected override void LaunchBrowser(Android.Net.Uri uri)
         {

--- a/src/Auth0.OidcClient.Android/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.Android/PlatformWebView.cs
@@ -4,7 +4,7 @@
     /// PlatformWebView offers the best platform-specific web view implementation
     /// at a given time. On Android that is the Chrome Custom Tabs at this time.
     /// </summary>
-    public class PlatformWebView : ChromeCustomTabsWebView
+    public class PlatformWebView : ChromeCustomTabsBrowser
     {
     }
 }

--- a/src/Auth0.OidcClient.Android/SystemBrowser.cs
+++ b/src/Auth0.OidcClient.Android/SystemBrowser.cs
@@ -3,7 +3,7 @@ using Android.Content;
 
 namespace Auth0.OidcClient
 {
-    public class SystemBrowserWebView : AndroidWebViewBase
+    public class SystemBrowser : AndroidWebViewBase
     {
         protected override void LaunchBrowser(Android.Net.Uri uri)
         {


### PR DESCRIPTION
Renaming these two classes from a WebView suffix to Browser suffix to match the IBrowser interface and the equivalent classes in the iOS codebase.

This is not a breaking change as these classes have not yet shipped.  The existing class that did ship - PlatformWebView - is remaining as-is for backward compatibility.