### PR TITLE
Prepare 3.0 beta

### DIFF
--- a/nuget/Auth0.OidcClient.Android.nuspec
+++ b/nuget/Auth0.OidcClient.Android.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.Android</id>
-    <version>2.4.0</version>
+    <version>3.0.0-beta1</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <licenseUrl>https://opensource.org/licenses/Apache-2.0</licenseUrl>
@@ -12,6 +12,12 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Xamarin Android applications</description>
     <releaseNotes>
+      Version 3.0.0
+      - Removed deprecated PlatformWebView class (breaking change). Either:
+        - Leave it null for ongoing best default (recommended)
+        - Assign an instance of ChromeCustomTabBrowser (will fall back if needed)
+        - Assign an instance of SystemBrowser (for old not-recommended behavior)
+
       Version 2.4.0
       - Add support for ChromeCustomTabs browser and made it default
       - PlatformWebView class is deprecated. When it comes to config.Browser either:
@@ -19,7 +25,7 @@
         - Assign an instance of ChromeCustomTabBrowser (will fall back if needed)
         - Assign an instance of SystemBrowser (for old not-recommended behavior)
       - Add new Auth0ClientActivity class to help in wiring up ActivityMediator
-        - Alternatively call ActivityMediator.Instance.Cancel() from your OnResume
+      - Alternatively call ActivityMediator.Instance.Cancel() from your OnResume
       - Move system browser integration to SystemBrowser class
       - Add return code status for Logout (thanks @jsauve)
       - Add support to get the user claims from the userinfo endpoint (thanks @OrihuelaConde)
@@ -56,7 +62,7 @@
     <tags>Auth0 OIDC Android MonoAndroid</tags>
     <dependencies>
       <group targetFramework="MonoAndroid10">
-        <dependency id="Auth0.OidcClient.Core" version="2.4.0" />
+        <dependency id="Auth0.OidcClient.Core" version="3.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.Core.nuspec
+++ b/nuget/Auth0.OidcClient.Core.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.Core</id>
-    <version>2.4.0</version>
+    <version>3.0.0-beta1</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <licenseUrl>https://opensource.org/licenses/Apache-2.0</licenseUrl>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Native applications</description>
     <releaseNotes>
+      Version 3.0.0
+      - No changes in Auth0.OidcClient.Core, version bumped for changes to dependant libraries.
+
       Version 2.4.0
       - Add return code status for Logout (thanks @jsauve)
       - Add support to get the user claims from the userinfo endpoint (thanks @OrihuelaConde)

--- a/nuget/Auth0.OidcClient.UWP.nuspec
+++ b/nuget/Auth0.OidcClient.UWP.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.UWP</id>
-    <version>2.4.0</version>
+    <version>3.0.0-beta1</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <licenseUrl>https://opensource.org/licenses/Apache-2.0</licenseUrl>
@@ -12,6 +12,11 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Universal Windows Platform (UWP) applications</description>
     <releaseNotes>
+      Version 3.0.0
+      - Removed deprecated PlatformWebView class (breaking change). Either:
+        - Leave it null for ongoing best default (recommended)
+        - Assign an instance of WebAuthenticationBrokerBrowser passing true to enable Windows auth
+
       Version 2.4.0
       - Add return code status for Logout (thanks @jsauve)
       - PlatformWebView class is deprecated. When it comes to config.Browser either:
@@ -48,7 +53,7 @@
     <tags>Auth0 OIDC UWP Windows10</tags>
     <dependencies>
       <group targetFramework="uap10.0">
-        <dependency id="Auth0.OidcClient.Core" version="2.4.0" />
+        <dependency id="Auth0.OidcClient.Core" version="3.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.WPF.nuspec
+++ b/nuget/Auth0.OidcClient.WPF.nuspec
@@ -3,15 +3,23 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.WPF</id>
-    <version>2.4.0</version>
+    <version>3.0.0-beta1</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <licenseUrl>https://opensource.org/licenses/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/auth0/auth0-oidc-client-net</projectUrl>
     <iconUrl>http://secure.gravatar.com/avatar/805765c256ff8617fcad483b5476faf2</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Auth0 OIDC Client for WPF applications</description>
+    <description>Auth0 OIDC Client for Windows Presentation Foundation (WPF) applications</description>
     <releaseNotes>
+      Version 3.0.0
+      - Add WebViewBrowser class with Edge browser support for improved compatibility (new default).
+      - Now requires .NET Framework 4.6.2 (previously 4.5.2, breaking change).
+      - Removed deprecated PlatformWebView class (breaking change). Either:
+        - Leave it null for ongoing best default (recommended)
+        - Assign an instance of WebBrowserBrowser passing a custom Window function if customization and IE needed
+        - Assign an instance of WebViewBrowser passing a custom Window function if customization and Edge needed
+      
       Version 2.4.0
       - Add support for closing the browser window (thanks @aashikgowda)
       - PlatformWebView class is deprecated. When it comes to config.Browser either:
@@ -51,7 +59,7 @@
     <tags>Auth0 OIDC WPF</tags>
     <dependencies>
       <group targetFramework="net452">
-        <dependency id="Auth0.OidcClient.Core" version="2.4.0" />
+        <dependency id="Auth0.OidcClient.Core" version="3.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.WinForms.nuspec
+++ b/nuget/Auth0.OidcClient.WinForms.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.WinForms</id>
-    <version>2.4.0</version>
+    <version>3.0.0-beta1</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <licenseUrl>https://opensource.org/licenses/Apache-2.0</licenseUrl>
@@ -12,6 +12,13 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Windows Forms applications</description>
     <releaseNotes>
+      - Add WebViewBrowser class with Edge browser support for improved compatibility (new default).
+      - Now requires .NET Framework 4.6.2 (previously 4.5.2, breaking change).
+      - Removed deprecated PlatformWebView class (breaking change). Either:
+        - Leave it null for ongoing best default (recommended)
+        - Assign an instance of WebBrowserBrowser passing a custom Form function if customization and IE needed
+        - Assign an instance of WebViewBrowser passing a custom Form function if customization and Edge needed
+      
       Version 2.4.0
       - Add return code status for Logout (thanks @jsauve)
       - PlatformWebView class is deprecated. When it comes to config.Browser either:
@@ -50,7 +57,7 @@
     <tags>Auth0 OIDC WinForms</tags>
     <dependencies>
       <group targetFramework="net452">
-        <dependency id="Auth0.OidcClient.Core" version="2.4.0" />
+        <dependency id="Auth0.OidcClient.Core" version="3.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.iOS.nuspec
+++ b/nuget/Auth0.OidcClient.iOS.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.iOS</id>
-    <version>2.4.0</version>
+    <version>3.0.0-beta1</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <licenseUrl>https://opensource.org/licenses/Apache-2.0</licenseUrl>
@@ -12,6 +12,11 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Xamarin iOS applications</description>
     <releaseNotes>
+      Version 3.0.0
+      - Removed deprecated PlatformWebView class (breaking change). Either:
+        - Leave it null to auto-switch based on iOS version (recommended)
+        - Assign an instance of SFSafariViewControllerBrowser for old iOS 9 style promptless
+
       Version 2.4.0
       - Add ASWebAuthenticationSession for iOS 12+ (thanks @jsauve)
       - PlatformWebView class is deprecated. When it comes to config.Browser either:
@@ -49,7 +54,7 @@
     <tags>Auth0 OIDC iOS MonoTouch</tags>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
-        <dependency id="Auth0.OidcClient.Core" version="2.4.0" />
+        <dependency id="Auth0.OidcClient.Core" version="3.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
+++ b/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
@@ -51,7 +51,6 @@
     <Compile Include="Auth0Client.cs" />
     <Compile Include="Auth0ClientActivity.cs" />
     <Compile Include="ChromeCustomTabsBrowser.cs" />
-    <Compile Include="PlatformWebView.cs" />
     <Compile Include="SystemBrowser.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Auth0.OidcClient.Android/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.Android/PlatformWebView.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace Auth0.OidcClient
-{
-    [Obsolete("It is recommended you leave Browser unassigned to accept the library default of ChromeCustomTabsBrowser.")]
-    public class PlatformWebView : SystemBrowser
-    {
-    }
-}

--- a/src/Auth0.OidcClient.Android/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.Android/Properties/AssemblyInfo.cs
@@ -8,5 +8,6 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("2.4.0")]
-[assembly: AssemblyFileVersion("2.4.0")]
+[assembly: AssemblyVersion("3.0.0.1")]
+[assembly: AssemblyFileVersion("3.0.0.1")]
+[assembly: AssemblyInformationalVersion("3.0.0.1-beta1")]

--- a/src/Auth0.OidcClient.Android/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.Android/Properties/AssemblyInfo.cs
@@ -1,30 +1,12 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Android.App;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Auth0.OidcClient.Android")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Auth0.OidcClient.Android")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+[assembly: AssemblyProduct("Auth0.OidcClient")]
+[assembly: AssemblyCompany("Auth0 Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2017-2019 Auth0 Inc.")]
+
 [assembly: ComVisible(false)]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.4.0")]
 [assembly: AssemblyFileVersion("2.4.0")]

--- a/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
+++ b/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
@@ -3,9 +3,10 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.4;netstandard2.0;net452</TargetFrameworks>
     <RootNamespace>Auth0.OidcClient</RootNamespace>
-    <AssemblyVersion>2.4.0.0</AssemblyVersion>
-    <FileVersion>2.4.0.0</FileVersion>
-    <Version>2.4.0</Version>
+    <Version>3.0.0.1</Version>
+    <AssemblyVersion>3.0.0.1</AssemblyVersion>
+    <FileVersion>3.0.0.1</FileVersion>
+    <InformationalVersion>3.0.0.1-beta1</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/src/Auth0.OidcClient.UWP/Auth0Client.cs
+++ b/src/Auth0.OidcClient.UWP/Auth0Client.cs
@@ -1,7 +1,4 @@
-﻿using Windows.Security.Authentication.Web;
-using Windows.UI.Xaml;
-
-namespace Auth0.OidcClient
+﻿namespace Auth0.OidcClient
 {
     /// <summary>
     /// Primary class for performing authentication and authorization operations with Auth0 using the

--- a/src/Auth0.OidcClient.UWP/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.UWP/Properties/AssemblyInfo.cs
@@ -8,5 +8,6 @@ using System.Runtime.InteropServices;
 
 [assembly: ComVisible(false)]
 
-[assembly: AssemblyVersion("2.4.0")]
-[assembly: AssemblyFileVersion("2.4.0")]
+[assembly: AssemblyVersion("3.0.0.1")]
+[assembly: AssemblyFileVersion("3.0.0.1")]
+[assembly: AssemblyInformationalVersion("3.0.0.1-beta1")]

--- a/src/Auth0.OidcClient.UWP/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.UWP/Properties/AssemblyInfo.cs
@@ -1,29 +1,12 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Auth0.OidcClient.UWP")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Auth0.OidcClient.UWP")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+[assembly: AssemblyProduct("Auth0.OidcClient")]
+[assembly: AssemblyCompany("Auth0 Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2017-2019 Auth0 Inc.")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
+[assembly: ComVisible(false)]
+
 [assembly: AssemblyVersion("2.4.0")]
 [assembly: AssemblyFileVersion("2.4.0")]
-[assembly: ComVisible(false)]

--- a/src/Auth0.OidcClient.WPF/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.WPF/Properties/AssemblyInfo.cs
@@ -1,55 +1,18 @@
 ﻿using System.Reflection;
-using System.Resources;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Windows;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Auth0.OidcClient.WPF")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Auth0.OidcClient.WPF")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+[assembly: AssemblyProduct("Auth0.OidcClient")]
+[assembly: AssemblyCompany("Auth0 Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2017-2019 Auth0 Inc.")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
-//In order to begin building localizable applications, set 
-//<UICulture>CultureYouAreCodingWith</UICulture> in your .csproj file
-//inside a <PropertyGroup>.  For example, if you are using US english
-//in your source files, set the <UICulture> to en-US.  Then uncomment
-//the NeutralResourceLanguage attribute below.  Update the "en-US" in
-//the line below to match the UICulture setting in the project file.
-
-//[assembly: NeutralResourcesLanguage("en-US", UltimateResourceFallbackLocation.Satellite)]
-
-
 [assembly:ThemeInfo(
-    ResourceDictionaryLocation.None, //where theme specific resource dictionaries are located
-                             //(used if a resource is not found in the page, 
-                             // or application resource dictionaries)
-    ResourceDictionaryLocation.SourceAssembly //where the generic resource dictionary is located
-                                      //(used if a resource is not found in the page, 
-                                      // app, or any theme specific resource dictionaries)
+    ResourceDictionaryLocation.None,
+    ResourceDictionaryLocation.SourceAssembly
 )]
 
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.4.0")]
 [assembly: AssemblyFileVersion("2.4.0")]

--- a/src/Auth0.OidcClient.WPF/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.WPF/Properties/AssemblyInfo.cs
@@ -14,5 +14,6 @@ using System.Windows;
     ResourceDictionaryLocation.SourceAssembly
 )]
 
-[assembly: AssemblyVersion("2.4.0")]
-[assembly: AssemblyFileVersion("2.4.0")]
+[assembly: AssemblyVersion("3.0.0.1")]
+[assembly: AssemblyFileVersion("3.0.0.1")]
+[assembly: AssemblyInformationalVersion("3.0.0.1-beta1")]

--- a/src/Auth0.OidcClient.WinForms/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.WinForms/Properties/AssemblyInfo.cs
@@ -1,36 +1,13 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
 [assembly: AssemblyTitle("Auth0.OidcClient.WinForms")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Auth0.OidcClient.WinForms")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+[assembly: AssemblyProduct("Auth0.OidcClient")]
+[assembly: AssemblyCompany("Auth0 Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2017-2019 Auth0 Inc.")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("34085d04-7e7b-4a5e-8377-d3995983919e")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.4.0")]
 [assembly: AssemblyFileVersion("2.4.0")]

--- a/src/Auth0.OidcClient.WinForms/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.WinForms/Properties/AssemblyInfo.cs
@@ -9,5 +9,6 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("34085d04-7e7b-4a5e-8377-d3995983919e")]
 
-[assembly: AssemblyVersion("2.4.0")]
-[assembly: AssemblyFileVersion("2.4.0")]
+[assembly: AssemblyVersion("3.0.0.1")]
+[assembly: AssemblyFileVersion("3.0.0.1")]
+[assembly: AssemblyInformationalVersion("3.0.0.1-beta1")]

--- a/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
+++ b/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
@@ -51,7 +51,6 @@
     <Compile Include="SFAuthenticationSessionBrowser.cs" />
     <Compile Include="SFSafariViewControllerBrowser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="PlatformWebView.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Auth0.OidcClient.Core\Auth0.OidcClient.Core.csproj">

--- a/src/Auth0.OidcClient.iOS/PlatformWebView.cs
+++ b/src/Auth0.OidcClient.iOS/PlatformWebView.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace Auth0.OidcClient
-{
-    [Obsolete("It is recommended you leave Browser unassigned to accept the library default of AutoSelectBrowser.")]
-    public class PlatformWebView : AutoSelectBrowser
-    {
-    }
-}

--- a/src/Auth0.OidcClient.iOS/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.iOS/Properties/AssemblyInfo.cs
@@ -1,36 +1,13 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("Auth0.OidcClient.iOS")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Auth0.OidcClient.iOS")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
+[assembly: AssemblyTitle("Auth0.OidcClient.Android")]
+[assembly: AssemblyProduct("Auth0.OidcClient")]
+[assembly: AssemblyCompany("Auth0 Inc.")]
+[assembly: AssemblyCopyright("Copyright © 2017-2019 Auth0 Inc.")]
 
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
-// The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("d6cd228a-d8fa-4250-b770-ccc9ccd5698b")]
 
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.4.0")]
 [assembly: AssemblyFileVersion("2.4.0")]

--- a/src/Auth0.OidcClient.iOS/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.iOS/Properties/AssemblyInfo.cs
@@ -9,5 +9,6 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("d6cd228a-d8fa-4250-b770-ccc9ccd5698b")]
 
-[assembly: AssemblyVersion("2.4.0")]
-[assembly: AssemblyFileVersion("2.4.0")]
+[assembly: AssemblyVersion("3.0.0.1")]
+[assembly: AssemblyFileVersion("3.0.0.1")]
+[assembly: AssemblyInformationalVersion("3.0.0.1-beta1")]


### PR DESCRIPTION
There is one main new feature in 3.0 which is the new WebViewBrowser control which uses Microsoft Edge instead of IE when available (avoids the big warning on GitHub login pages).

To do this required bumping the .NET Framework version number to 4.6.2 which is a breaking change so also took this opportunity to remove the already-deprecated PlatformWebView classes.