### PR TITLE
Set PresentationAnchor on iOS13 ASWebAuthenticationSession browser

### DIFF
--- a/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
@@ -2,6 +2,7 @@
 using Foundation;
 using IdentityModel.OidcClient.Browser;
 using System.Threading.Tasks;
+using UIKit;
 
 namespace Auth0.OidcClient
 {
@@ -29,9 +30,21 @@ namespace Auth0.OidcClient
                     asWebAuthenticationSession.Dispose();
                 });
 
+            // iOS 13 requires the PresentationContextProvider set
+            if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+                asWebAuthenticationSession.PresentationContextProvider = new PresentationContextProviderToSharedKeyWindow();
+
             asWebAuthenticationSession.Start();
 
             return tcs.Task;
+        }
+
+        class PresentationContextProviderToSharedKeyWindow : NSObject, IASWebAuthenticationPresentationContextProviding
+        {
+            public UIWindow GetPresentationAnchor(ASWebAuthenticationSession session)
+            {
+                return UIApplication.SharedApplication.KeyWindow;
+            }
         }
 
         private static BrowserResult CreateBrowserResult(NSUrl callbackUrl, NSError error)


### PR DESCRIPTION
Fixes #91 by allowing ASWebAuthenticationSession to obtain a presentation anchor. This is required now in iOS 13.

This library now requires iOS.Xamarin 12.99 or greater for this API https://docs.microsoft.com/en-us/xamarin/ios/release-notes/api-changes/ios-12-14-0-12-99-0 but runtime should work fine on previous iOS versions.

iOS.Xamarin 13 is included in VS 2019 v16.3.0 https://docs.microsoft.com/en-us/visualstudio/releases/2019/release-notes#details-of-whats-new-in-visual-studio-2019-version-1630

Azure Pipeline server might need upgrade. 