### PR TITLE
Add support for Edge on UWP/WinForms/WPF and make it default

### DIFF
--- a/src/Auth0.OidcClient.UWP/Auth0.OidcClient.UWP.csproj
+++ b/src/Auth0.OidcClient.UWP/Auth0.OidcClient.UWP.csproj
@@ -112,6 +112,7 @@
     <Compile Include="Auth0Client.cs" />
     <Compile Include="WebAuthenticationBrokerBrowser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WebViewBrowser.cs" />
     <EmbeddedResource Include="Properties\Auth0.OidcClient.UWP.rd.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Auth0.OidcClient.UWP/Auth0Client.cs
+++ b/src/Auth0.OidcClient.UWP/Auth0Client.cs
@@ -1,4 +1,5 @@
 ﻿using Windows.Security.Authentication.Web;
+using Windows.UI.Xaml;
 
 namespace Auth0.OidcClient
 {
@@ -15,8 +16,7 @@ namespace Auth0.OidcClient
         public Auth0Client(Auth0ClientOptions options)
             : base(options, "uwp")
         {
-            options.Browser = options.Browser ?? new WebAuthenticationBrokerBrowser();
-            options.RedirectUri = options.RedirectUri ?? WebAuthenticationBroker.GetCurrentApplicationCallbackUri().AbsoluteUri;
+            options.Browser = options.Browser ?? new WebViewBrowser();
         }
     }
 }

--- a/src/Auth0.OidcClient.UWP/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.UWP/WebViewBrowser.cs
@@ -1,0 +1,80 @@
+﻿using IdentityModel.OidcClient.Browser;
+using System;
+using System.Threading.Tasks;
+using Windows.ApplicationModel.Core;
+using Windows.UI.Core;
+using Windows.UI.ViewManagement;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Auth0.OidcClient
+{
+    /// <summary>
+    /// Implements the <see cref="IBrowser"/> interface using the <see cref="WebView"/> control.
+    /// </summary>
+    public class WebViewBrowser : IBrowser
+    {
+        /// <inheritdoc />
+        public Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        {
+            var tcs = new TaskCompletionSource<BrowserResult>();
+            var currentAppView = ApplicationView.GetForCurrentView();
+
+            RunOnNewView(async () => {
+                var newAppView = CreateApplicationView();
+                var webView = CreateWebView(Window.Current, options, tcs);
+                webView.Navigate(new Uri(options.StartUrl));
+                await ApplicationViewSwitcher.TryShowAsStandaloneAsync(newAppView.Id, ViewSizePreference.UseMinimum, currentAppView.Id, ViewSizePreference.UseMinimum);
+            });
+
+            return tcs.Task;
+        }
+
+        private async void RunOnNewView(DispatchedHandler function)
+        {
+            await CoreApplication.CreateNewView().Dispatcher.RunAsync(CoreDispatcherPriority.Normal, function);
+        }
+
+        private static ApplicationView CreateApplicationView()
+        {
+            var appView = ApplicationView.GetForCurrentView();
+            appView.Title = "Authentication...";
+            return appView;
+        }
+
+        private static WebView CreateWebView(Window window, BrowserOptions options, TaskCompletionSource<BrowserResult> tcs)
+        {
+            var webView = new WebView();
+
+            webView.NavigationStarting += (sender, e) =>
+            {
+                if (e.Uri.AbsoluteUri.StartsWith(options.EndUrl))
+                {
+                    tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.Success, Response = e.Uri.ToString() });
+                    window.Close();
+                }
+            };
+
+            webView.NavigationFailed += (sender, e) =>
+            {
+                tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.UnknownError, Error = e.WebErrorStatus.ToString() });
+                window.Close();
+            };
+
+            // There is no closed event so the best we can do is detect visibility. This means we close when they minimize too.
+            window.VisibilityChanged += (sender, e) =>
+            {
+                if (!window.Visible && !tcs.Task.IsCompleted)
+                {
+                    tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.UserCancel });
+                    window.Close();
+                }
+            };
+
+            window.Content = webView;
+            window.Activate();
+
+            return webView;
+        }
+    }
+}

--- a/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
+++ b/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
@@ -67,6 +67,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <Compile Include="WebViewBrowser.cs" />
     <EmbeddedResource Include="Properties\Resources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
@@ -86,6 +87,9 @@
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
       <Version>2.9.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Toolkit.Wpf.UI.Controls.WebView">
+      <Version>5.1.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Auth0.OidcClient.WPF/Auth0Client.cs
+++ b/src/Auth0.OidcClient.WPF/Auth0Client.cs
@@ -13,7 +13,7 @@
         public Auth0Client(Auth0ClientOptions options)
             : base(options, "wpf")
         {
-            options.Browser = options.Browser ?? new WebBrowserBrowser();
+            options.Browser = options.Browser ?? new WebViewBrowser();
         }
     }
 }

--- a/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
@@ -1,0 +1,78 @@
+﻿using IdentityModel.OidcClient.Browser;
+using Microsoft.Toolkit.Wpf.UI.Controls;
+using System;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace Auth0.OidcClient
+{
+    /// <summary>
+    /// Implements the <see cref="IBrowser"/> interface using the <see cref="WebViewCompatible"/> control.
+    /// </summary>
+    public class WebViewBrowser : IBrowser
+    {
+        private readonly Func<Window> _windowFactory;
+        private readonly bool _shouldCloseWindow;
+
+        /// <summary>
+        /// Create a new instance of <see cref="WebViewBrowser"/> with a custom windowFactory and optional window close flag.
+        /// </summary>
+        /// <param name="windowFactory">A function that returns a <see cref="Window"/> to be used for hosting the browser.</param>
+        /// <param name="shouldCloseWindow"> Whether the Window should be closed or not after completion.</param>
+        public WebViewBrowser(Func<Window> windowFactory, bool shouldCloseWindow = true)
+        {
+            _windowFactory = windowFactory;
+            _shouldCloseWindow = shouldCloseWindow;
+        }
+
+        /// <summary>
+        /// Create a new instance of <see cref="WebViewBrowser"/> allowing parts of the <see cref="Window"/> container to be set.
+        /// </summary>
+        /// <param name="title">Optional title for the form - defaults to 'Authenticating...'.</param>
+        /// <param name="width">Optional width for the form in pixels. Defaults to 1024.</param>
+        /// <param name="height">Optional height for the form in pixels. Defaults to 768.</param>
+        public WebViewBrowser(string title = "Authenticating...", int width = 1024, int height = 768)
+            : this(() => new Window
+            {
+                Name = "WebAuthentication",
+                Title = title,
+                Width = width,
+                Height = height
+            })
+        {
+        }
+
+        /// <inheritdoc />
+        public Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        {
+            var tcs = new TaskCompletionSource<BrowserResult>();
+
+            var window = _windowFactory();
+            var webView = new WebViewCompatible();
+            window.Content = webView;
+
+            webView.NavigationStarting += (sender, e) =>
+            {
+                if (e.Uri.AbsoluteUri.StartsWith(options.EndUrl))
+                {
+                    tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.Success, Response = e.Uri.ToString() });
+                    if (_shouldCloseWindow)
+                        window.Close();
+                    else
+                        window.Content = null;
+                }
+            };
+
+            window.Closing += (sender, e) =>
+            {
+                if (!tcs.Task.IsCompleted)
+                    tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.UserCancel });
+            };
+
+            window.Show();
+            webView.Navigate(options.StartUrl);
+
+            return tcs.Task;
+        }
+    }
+}

--- a/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
+++ b/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
@@ -53,6 +53,7 @@
     </Compile>
     <Compile Include="WebBrowserBrowser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="WebViewBrowser.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.manifest" />
@@ -66,6 +67,9 @@
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
       <Version>2.9.1</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Toolkit.Forms.UI.Controls.WebView">
+      <Version>5.1.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Auth0.OidcClient.WinForms/Auth0Client.cs
+++ b/src/Auth0.OidcClient.WinForms/Auth0Client.cs
@@ -13,7 +13,7 @@
         public Auth0Client(Auth0ClientOptions options)
             : base(options, "winforms")
         {
-            options.Browser = options.Browser ?? new WebBrowserBrowser();
+            options.Browser = options.Browser ?? new WebViewBrowser();
         }
     }
 }

--- a/src/Auth0.OidcClient.WinForms/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WinForms/WebViewBrowser.cs
@@ -1,0 +1,74 @@
+﻿using IdentityModel.OidcClient.Browser;
+using Microsoft.Toolkit.Forms.UI.Controls;
+using System;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Auth0.OidcClient
+{
+    /// <summary>
+    /// Implements the <see cref="IBrowser"/> interface using the <see cref="WebViewCompatible"/> control.
+    /// </summary>
+    public class WebViewBrowser : IBrowser
+    {
+        private readonly Func<Form> _formFactory;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="WebViewBrowser"/> with a specified function to create the <see cref="Form"/>
+        /// used to host the <see cref="WebViewCompatible"/> control.
+        /// </summary>
+        /// <param name="formFactory">The function used to create the <see cref="Form"/> that will host the <see cref="WebViewCompatible"/> control.</param>
+        public WebViewBrowser(Func<Form> formFactory)
+        {
+            _formFactory = formFactory;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="WebViewBrowser"/> allowing parts of the <see cref="Form"/> container to be set.
+        /// </summary>
+        /// <param name="title">Optional title for the form - defaults to 'Authenticating...'.</param>
+        /// <param name="width">Optional width for the form in pixels. Defaults to 1024.</param>
+        /// <param name="height">Optional height for the form in pixels. Defaults to 768.</param>
+        public WebViewBrowser(string title = "Authenticating...", int width = 1024, int height = 768)
+            : this(() => new Form
+            {
+                Name = "WebAuthentication",
+                Text = title,
+                Width = width,
+                Height = height
+            })
+        {
+        }
+
+        /// </inheritdoc>
+        public Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        {
+            var tcs = new TaskCompletionSource<BrowserResult>();
+
+            var window = _formFactory();
+            var webView = new WebViewCompatible { Dock = DockStyle.Fill };
+
+            webView.NavigationStarting += (sender, e) =>
+            {
+                if (e.Uri.AbsoluteUri.StartsWith(options.EndUrl))
+                {
+                    tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.Success, Response = e.Uri.ToString() });
+                    window.Close();
+                }
+            };
+
+            window.Closing += (sender, e) =>
+            {
+                if (!tcs.Task.IsCompleted)
+                    tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.UserCancel });
+            };
+
+
+            window.Controls.Add(webView);
+            window.Show();
+            webView.Navigate(options.StartUrl);
+
+            return tcs.Task;
+        }
+    }
+}


### PR DESCRIPTION
Internet Explorer is very old but that's all our Windows platforms currently support.

This PR brings in support for Microsoft Edge browser and falls back to IE when it can't use it.

This means some SSO pages like GitHub's won't get upset and complain you're using IE.

Windows Authentication support on UWP changes, that will need to be documented in the 3.0 migration guide.