### PR TITLE
Ensure auto binding redirects on iOS test app

### DIFF
--- a/test/iOS/iOS.csproj
+++ b/test/iOS/iOS.csproj
@@ -11,6 +11,7 @@
     <AssemblyName>iOSTestApp</AssemblyName>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Stops compiler warning.