### PR TITLE
Fix ASWebAutenticationSessionBrowser not working when used directly

### DIFF
--- a/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
@@ -14,7 +14,7 @@ namespace Auth0.OidcClient
         /// <inheritdoc/>
         protected override Task<BrowserResult> Launch(BrowserOptions options)
         {
-            return Launch(options);
+            return Start(options);
         }
 
         internal static Task<BrowserResult> Start(BrowserOptions options)


### PR DESCRIPTION
Normally we use `ASWebAutenticationSessionBrowser` via `AutoSelectBrowser` - it is the default - and it works fine.

You should however be able to also assign an instance to Browser to use only this mechanism. There was a bug that prevented this scenario from being usable however where the Launch method inadvertently called itself instead of Start.