### PR TITLE
Add extraParameters to ParseResponseAsync

### DIFF
--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -84,15 +84,15 @@ namespace Auth0.OidcClient
         }
 
         /// <inheritdoc/>
-        public Task<LoginResult> ProcessResponseAsync(string data, AuthorizeState state)
+        public Task<LoginResult> ProcessResponseAsync(string data, AuthorizeState state, object extraParameters = null)
         {
-            return OidcClient.ProcessResponseAsync(data, state);
+            return OidcClient.ProcessResponseAsync(data, state, AppendTelemetry(extraParameters));
         }
 
         /// <inheritdoc/>
         public Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, object extraParameters = null)
         {
-            return OidcClient.RefreshTokenAsync(refreshToken, extraParameters);
+            return OidcClient.RefreshTokenAsync(refreshToken, AppendTelemetry(extraParameters));
         }
 
         /// <inheritdoc/>

--- a/src/Auth0.OidcClient.Core/IAuth0Client.cs
+++ b/src/Auth0.OidcClient.Core/IAuth0Client.cs
@@ -42,8 +42,9 @@ namespace Auth0.OidcClient
         /// <param name="data">The data containing the full redirect URI.</param>
         /// <param name="state">The <see cref="AuthorizeState"/> which was generated when the <see cref="PrepareLoginAsync"/>
         /// method was called.</param>
+        /// <param name="extraParameters">Optional extra parameters that need to be passed to the endpoint.</param>
         /// <returns>A <see cref="LoginResult"/> containing the tokens and claims.</returns>
-        Task<LoginResult> ProcessResponseAsync(string data, AuthorizeState state);
+        Task<LoginResult> ProcessResponseAsync(string data, AuthorizeState state, object extraParameters = null);
 
         /// <summary>
         /// Generates a new set of tokens based on a refresh token. 


### PR DESCRIPTION
- `ParseResponseAsync` was missing `extraParameters` and so did not send telemetry (SDK user agent)
- `RefreshTokenAsync` was not sending telemetry (SDK user agent)