### PR TITLE
Update to IdentityModel.OidcClient 3

### DIFF
--- a/nuget/Auth0.OidcClient.Core.nuspec
+++ b/nuget/Auth0.OidcClient.Core.nuspec
@@ -42,7 +42,7 @@
     <tags>Auth0 OIDC</tags>
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="IdentityModel.OidcClient" version="2.9.1" />
+        <dependency id="IdentityModel.OidcClient" version="3.0.1" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Auth0.OidcClient.Android/AndroidBrowserBase.cs
+++ b/src/Auth0.OidcClient.Android/AndroidBrowserBase.cs
@@ -2,6 +2,7 @@
 using Android.Content;
 using IdentityModel.OidcClient.Browser;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Auth0.OidcClient
@@ -33,7 +34,7 @@ namespace Auth0.OidcClient
         }
 
         /// <inheritdoc/>
-        public Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        public Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(options.StartUrl))
                 throw new ArgumentException("Missing StartUrl", nameof(options));

--- a/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
+++ b/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
@@ -67,7 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>2.9.1</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.CustomTabs">
       <Version>28.0.0.3</Version>

--- a/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
+++ b/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient" Version="2.9.1" />
+    <PackageReference Include="IdentityModel.OidcClient" Version="3.0.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using IdentityModel.Client;
 using IdentityModel.OidcClient;
@@ -41,7 +42,7 @@ namespace Auth0.OidcClient
         }
 
         /// <inheritdoc />
-        public Task<LoginResult> LoginAsync(object extraParameters = null)
+        public Task<LoginResult> LoginAsync(object extraParameters = null, CancellationToken cancellationToken = default)
         {
             var loginRequest = new LoginRequest
             {
@@ -49,11 +50,11 @@ namespace Auth0.OidcClient
             };
 
             Debug.WriteLine($"Using Callback URL ${_options.RedirectUri}. Ensure this is an Allowed Callback URL for application/client ID ${_options.ClientId}.");
-            return OidcClient.LoginAsync(loginRequest);
+            return OidcClient.LoginAsync(loginRequest, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<BrowserResultType> LogoutAsync(bool federated = false, object extraParameters = null)
+        public async Task<BrowserResultType> LogoutAsync(bool federated = false, object extraParameters = null, CancellationToken cancellationToken = default)
         {
             Debug.WriteLine($"Using Callback URL ${_options.PostLogoutRedirectUri}. Ensure this is an Allowed Logout URL for application/client ID ${_options.ClientId}.");
 
@@ -72,27 +73,27 @@ namespace Auth0.OidcClient
                 DisplayMode = logoutRequest.BrowserDisplayMode
             };
 
-            var browserResult = await OidcClient.Options.Browser.InvokeAsync(browserOptions);
+            var browserResult = await OidcClient.Options.Browser.InvokeAsync(browserOptions, cancellationToken);
 
             return browserResult.ResultType;
         }
 
         /// <inheritdoc/>
-        public Task<AuthorizeState> PrepareLoginAsync(object extraParameters = null)
+        public Task<AuthorizeState> PrepareLoginAsync(object extraParameters = null, CancellationToken cancellationToken = default)
         {
-            return OidcClient.PrepareLoginAsync(AppendTelemetry(extraParameters));
+            return OidcClient.PrepareLoginAsync(AppendTelemetry(extraParameters), cancellationToken);
         }
 
         /// <inheritdoc/>
-        public Task<LoginResult> ProcessResponseAsync(string data, AuthorizeState state, object extraParameters = null)
+        public Task<LoginResult> ProcessResponseAsync(string data, AuthorizeState state, object extraParameters = null, CancellationToken cancellationToken = default)
         {
-            return OidcClient.ProcessResponseAsync(data, state, AppendTelemetry(extraParameters));
+            return OidcClient.ProcessResponseAsync(data, state, AppendTelemetry(extraParameters), cancellationToken);
         }
 
         /// <inheritdoc/>
-        public Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, object extraParameters = null)
+        public Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, object extraParameters = null, CancellationToken cancellationToken = default)
         {
-            return OidcClient.RefreshTokenAsync(refreshToken, AppendTelemetry(extraParameters));
+            return OidcClient.RefreshTokenAsync(refreshToken, AppendTelemetry(extraParameters), cancellationToken);
         }
 
         /// <inheritdoc/>

--- a/src/Auth0.OidcClient.Core/IAuth0Client.cs
+++ b/src/Auth0.OidcClient.Core/IAuth0Client.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using IdentityModel.OidcClient;
 using IdentityModel.OidcClient.Browser;
@@ -16,16 +17,18 @@ namespace Auth0.OidcClient
         /// Launches a browser to log the user in.
         /// </summary>
         /// <param name="extraParameters">Optional extra parameters that need to be passed to the endpoint.</param>
+        /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> that can be used to cancel the request.</param>
         /// <returns>A <see cref="LoginResult"/> containing the tokens and claims.</returns>
-        Task<LoginResult> LoginAsync(object extraParameters = null);
+        Task<LoginResult> LoginAsync(object extraParameters = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Launches a browser to log the user out and clear the Auth0 SSO Cookie.
         /// </summary>
         /// <param name="federated">Whether to log the user out of their federated identity provider. Defaults to false.</param>
         /// <param name="extraParameters">Optional extra parameters that need to be passed to the endpoint.</param>
+        /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> that can be used to cancel the request.</param>
         /// <returns>A <see cref="BrowserResultType"/> indicating whether the logout was successful.</returns>
-        Task<BrowserResultType> LogoutAsync(bool federated = false, object extraParameters = null);
+        Task<BrowserResultType> LogoutAsync(bool federated = false, object extraParameters = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Generates an <see cref="AuthorizeState"/> containing the URL, state, nonce and code challenge which can
@@ -33,8 +36,9 @@ namespace Auth0.OidcClient
         /// the <see cref="ProcessResponseAsync"/> method.
         /// </summary>
         /// <param name="extraParameters">Optional extra parameters that need to be passed to the endpoint.</param>
+        /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> that can be used to cancel the request.</param>
         /// <returns>A <see cref="AuthorizeState"/> with necessary URLs, nonce, state and code verifiers.</returns>
-        Task<AuthorizeState> PrepareLoginAsync(object extraParameters = null);
+        Task<AuthorizeState> PrepareLoginAsync(object extraParameters = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Process the response from the Auth0 redirect URI.
@@ -43,8 +47,10 @@ namespace Auth0.OidcClient
         /// <param name="state">The <see cref="AuthorizeState"/> which was generated when the <see cref="PrepareLoginAsync"/>
         /// method was called.</param>
         /// <param name="extraParameters">Optional extra parameters that need to be passed to the endpoint.</param>
+        /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> that can be used to cancel the request.</param>
         /// <returns>A <see cref="LoginResult"/> containing the tokens and claims.</returns>
-        Task<LoginResult> ProcessResponseAsync(string data, AuthorizeState state, object extraParameters = null);
+        Task<LoginResult> ProcessResponseAsync(string data, AuthorizeState state, object extraParameters = null, CancellationToken cancellationToken = default);
+        /// <returns>A <see cref="LoginResult"/> containing the tokens and claims.</returns>
 
         /// <summary>
         /// Generates a new set of tokens based on a refresh token. 
@@ -52,8 +58,9 @@ namespace Auth0.OidcClient
         /// <param name="refreshToken">Refresh token which was issued during the authorization flow, or subsequent
         /// calls to <see cref="IdentityModel.OidcClient.OidcClient.RefreshTokenAsync"/>.</param>
         /// <param name="extraParameters">Optional extra parameters that need to be passed to the endpoint.</param>
+        /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> that can be used to cancel the request.</param>
         /// <returns>A <see cref="RefreshTokenResult"/> with the refreshed tokens.</returns>
-        Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, object extraParameters = null);
+        Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, object extraParameters = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the user claims from the userinfo endpoint.

--- a/src/Auth0.OidcClient.UWP/WebAuthenticationBrokerBrowser.cs
+++ b/src/Auth0.OidcClient.UWP/WebAuthenticationBrokerBrowser.cs
@@ -1,5 +1,6 @@
 ﻿using IdentityModel.OidcClient.Browser;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.Security.Authentication.Web;
 
@@ -23,7 +24,7 @@ namespace Auth0.OidcClient
         }
 
         /// <inheritdoc />
-        public async Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        public async Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(options.StartUrl))
                 throw new ArgumentException("Missing StartUrl", nameof(options));

--- a/src/Auth0.OidcClient.UWP/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.UWP/WebViewBrowser.cs
@@ -1,5 +1,6 @@
 ﻿using IdentityModel.OidcClient.Browser;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
@@ -15,7 +16,7 @@ namespace Auth0.OidcClient
     public class WebViewBrowser : IBrowser
     {
         /// <inheritdoc />
-        public Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        public Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default)
         {
             var tcs = new TaskCompletionSource<BrowserResult>();
             var currentAppView = ApplicationView.GetForCurrentView();

--- a/src/Auth0.OidcClient.UWP/project.json
+++ b/src/Auth0.OidcClient.UWP/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "IdentityModel.OidcClient": "2.9.1",
+    "IdentityModel.OidcClient": "3.0.1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
   },
   "frameworks": {

--- a/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
+++ b/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
@@ -86,7 +86,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>2.9.1</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Wpf.UI.Controls.WebView">
       <Version>5.1.1</Version>

--- a/src/Auth0.OidcClient.WPF/WebBrowserBrowser.cs
+++ b/src/Auth0.OidcClient.WPF/WebBrowserBrowser.cs
@@ -54,7 +54,7 @@ namespace Auth0.OidcClient
         }
 
         /// <inheritdoc />
-        public async Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        public async Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default)
         {
             var window = _windowFactory.Invoke();
             using (var browser = new WebBrowser())

--- a/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
@@ -1,6 +1,7 @@
 ﻿using IdentityModel.OidcClient.Browser;
 using Microsoft.Toolkit.Wpf.UI.Controls;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 
@@ -43,7 +44,7 @@ namespace Auth0.OidcClient
         }
 
         /// <inheritdoc />
-        public Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        public Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default)
         {
             var tcs = new TaskCompletionSource<BrowserResult>();
 

--- a/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
+++ b/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
@@ -66,7 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>2.9.1</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Forms.UI.Controls.WebView">
       <Version>5.1.1</Version>

--- a/src/Auth0.OidcClient.WinForms/WebBrowserBrowser.cs
+++ b/src/Auth0.OidcClient.WinForms/WebBrowserBrowser.cs
@@ -44,7 +44,7 @@ namespace Auth0.OidcClient
         }
 
         /// <inheritdoc />
-        public async Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        public async Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default)
         {
             using (var form = _formFactory.Invoke())
             using (var browser = new ExtendedWebBrowser()

--- a/src/Auth0.OidcClient.WinForms/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WinForms/WebViewBrowser.cs
@@ -1,6 +1,7 @@
 ﻿using IdentityModel.OidcClient.Browser;
 using Microsoft.Toolkit.Forms.UI.Controls;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
@@ -41,7 +42,7 @@ namespace Auth0.OidcClient
         }
 
         /// <inheritdoc />
-        public Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        public Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default)
         {
             var tcs = new TaskCompletionSource<BrowserResult>();
 

--- a/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
@@ -1,6 +1,7 @@
 ﻿using AuthenticationServices;
 using Foundation;
 using IdentityModel.OidcClient.Browser;
+using System.Threading;
 using System.Threading.Tasks;
 using UIKit;
 
@@ -12,7 +13,7 @@ namespace Auth0.OidcClient
     public class ASWebAuthenticationSessionBrowser : IOSBrowserBase
     {
         /// <inheritdoc/>
-        protected override Task<BrowserResult> Launch(BrowserOptions options)
+        protected override Task<BrowserResult> Launch(BrowserOptions options, CancellationToken cancellationToken = default)
         {
             return Start(options);
         }

--- a/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
+++ b/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>2.9.1</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/src/Auth0.OidcClient.iOS/AutoSelectBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/AutoSelectBrowser.cs
@@ -1,4 +1,5 @@
 ﻿using IdentityModel.OidcClient.Browser;
+using System.Threading;
 using System.Threading.Tasks;
 using UIKit;
 
@@ -10,7 +11,7 @@ namespace Auth0.OidcClient
     public class AutoSelectBrowser : IOSBrowserBase
     {
         /// <inheritdoc/>
-        protected override Task<BrowserResult> Launch(BrowserOptions options)
+        protected override Task<BrowserResult> Launch(BrowserOptions options, CancellationToken cancellationToken = default)
         {
             // For iOS 12+ use ASWebAuthenticationSession
             if (UIDevice.CurrentDevice.CheckSystemVersion(12, 0))

--- a/src/Auth0.OidcClient.iOS/SFAuthenticationSessionBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/SFAuthenticationSessionBrowser.cs
@@ -1,6 +1,7 @@
 ﻿using Foundation;
 using IdentityModel.OidcClient.Browser;
 using SafariServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Auth0.OidcClient
@@ -11,7 +12,7 @@ namespace Auth0.OidcClient
     public class SFAuthenticationSessionBrowser : IOSBrowserBase
     {
         /// <inheritdoc/>
-        protected override Task<BrowserResult> Launch(BrowserOptions options)
+        protected override Task<BrowserResult> Launch(BrowserOptions options, CancellationToken cancellationToken = default)
         {
             return Start(options);
         }

--- a/src/Auth0.OidcClient.iOS/SFSafariViewControllerBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/SFSafariViewControllerBrowser.cs
@@ -1,6 +1,7 @@
 ﻿using Foundation;
 using IdentityModel.OidcClient.Browser;
 using SafariServices;
+using System.Threading;
 using System.Threading.Tasks;
 using UIKit;
 
@@ -12,7 +13,7 @@ namespace Auth0.OidcClient
     public class SFSafariViewControllerBrowser : IOSBrowserBase
     {
         /// <inheritdoc/>
-        protected override Task<BrowserResult> Launch(BrowserOptions options)
+        protected override Task<BrowserResult> Launch(BrowserOptions options, CancellationToken cancellationToken = default)
         {
             return Start(options);
         }

--- a/src/Auth0.OidcClient.iOS/iOSBrowserBase.cs
+++ b/src/Auth0.OidcClient.iOS/iOSBrowserBase.cs
@@ -1,5 +1,6 @@
 ﻿using IdentityModel.OidcClient.Browser;
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Auth0.OidcClient
@@ -10,7 +11,7 @@ namespace Auth0.OidcClient
     public abstract class IOSBrowserBase : IBrowser
     {
         /// <inheritdoc/>
-        public Task<BrowserResult> InvokeAsync(BrowserOptions options)
+        public Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(options.StartUrl))
                 throw new ArgumentException("Missing StartUrl", nameof(options));
@@ -18,16 +19,17 @@ namespace Auth0.OidcClient
             if (string.IsNullOrWhiteSpace(options.EndUrl))
                 throw new ArgumentException("Missing EndUrl", nameof(options));
 
-            return Launch(options);
+            return Launch(options, cancellationToken);
         }
 
         /// <summary>
         /// Launch a browser with the options and URL specified by the <see cref="BrowserOptions"/>.
         /// </summary>
-        /// <param name="options"></param>
+        /// <param name="options"><see cref="BrowserOptions"/> specifying the parameters to be used in launching the browser.</param>
+        /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> that could be used to cancel the browser.</param>
         /// <returns>A <see cref="Task"/> that will contain a <see cref="BrowserResult"/> with details of
         /// wether the launch process succeeded or not by way of a <see cref="BrowserResultType"/>.</returns>
-        protected abstract Task<BrowserResult> Launch(BrowserOptions options);
+        protected abstract Task<BrowserResult> Launch(BrowserOptions options, CancellationToken cancellationToken = default);
 
         internal static BrowserResult Canceled()
         {

--- a/test/Android/Android.csproj
+++ b/test/Android/Android.csproj
@@ -88,7 +88,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>2.9.1</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/test/UWP/project.json
+++ b/test/UWP/project.json
@@ -1,10 +1,10 @@
 ﻿{
   "dependencies": {
-    "IdentityModel.OidcClient": "2.9.1",
+    "IdentityModel.OidcClient": "3.0.1",
     "Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
   },
   "frameworks": {
-    "uap10.0.16299": {}
+    "uap10.0.17763": {}
   },
   "runtimes": {
     "win10-arm": {},

--- a/test/WPF/WPF.csproj
+++ b/test/WPF/WPF.csproj
@@ -107,7 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>2.9.1</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/WinForms/WinForms.csproj
+++ b/test/WinForms/WinForms.csproj
@@ -123,7 +123,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>2.9.1</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/iOS/iOS.csproj
+++ b/test/iOS/iOS.csproj
@@ -129,7 +129,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>2.9.1</Version>
+      <Version>3.0.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Updates IdentityModel.OidcClient to 3.0.0

The upstream dependency includes some breaking changes on interfaces as it adds CancellationTokens to all the Async requests.

We have taken the same approach for compatibility although at this time none of the CancellationTokens is actively checked to allow cancellation of the request. 

By adding the API support in this version we can introduce actual checking in a future minor with no breaking changes.

This is only a breaking change if the user has implemented IAuth0Client or IBrowser themselves (not a common case).