### PR TITLE
Clean up debug write format

### DIFF
--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -48,14 +48,14 @@ namespace Auth0.OidcClient
                 FrontChannelExtraParameters = AppendTelemetry(extraParameters)
             };
 
-            Debug.WriteLine($"Using Callback URL ${_options.RedirectUri}. Ensure this is an Allowed Callback URL for application/client ID ${_options.ClientId}.");
+            Debug.WriteLine($"Using Callback URL '{_options.RedirectUri}'. Ensure this is an Allowed Callback URL for application/client ID {_options.ClientId}.");
             return OidcClient.LoginAsync(loginRequest);
         }
 
         /// <inheritdoc/>
         public async Task<BrowserResultType> LogoutAsync(bool federated = false, object extraParameters = null)
         {
-            Debug.WriteLine($"Using Callback URL ${_options.PostLogoutRedirectUri}. Ensure this is an Allowed Logout URL for application/client ID ${_options.ClientId}.");
+            Debug.WriteLine($"Using Callback URL '{_options.PostLogoutRedirectUri}'. Ensure this is an Allowed Logout URL for application/client ID {_options.ClientId}.");
 
             var logoutParameters = AppendTelemetry(extraParameters);
             logoutParameters["client_id"] = OidcClient.Options.ClientId;


### PR DESCRIPTION
Somebody (me) must have thought they were using JavaScript for a hot second and used the wrong interpolated string format.