### PR TITLE
Improve scopes for OpenID Connect compliance

### DIFF
--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
@@ -103,12 +104,16 @@ namespace Auth0.OidcClient
 
         private OidcClientOptions CreateOidcClientOptions(Auth0ClientOptions options)
         {
+            var scopes = options.Scope.Split(' ').ToList();
+            if (!scopes.Contains("openid"))
+                scopes.Insert(0, "openid");
+
             var oidcClientOptions = new OidcClientOptions
             {
                 Authority = $"https://{options.Domain}",
                 ClientId = options.ClientId,
                 ClientSecret = options.ClientSecret,
-                Scope = options.Scope,
+                Scope = String.Join(" ", scopes),
                 LoadProfile = options.LoadProfile,
                 Browser = options.Browser,
                 Flow = AuthenticationFlow.AuthorizationCode,

--- a/src/Auth0.OidcClient.Core/Auth0ClientOptions.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientOptions.cs
@@ -110,7 +110,7 @@ namespace Auth0.OidcClient
         {
             EnableTelemetry = true;
             LoadProfile = true;
-            Scope = "openid profile";
+            Scope = "openid profile email";
         }
     }
 }

--- a/test/Android/MainActivity.cs
+++ b/test/Android/MainActivity.cs
@@ -30,8 +30,7 @@ namespace AndroidTestApp
             _auth0Client = new Auth0Client(new Auth0ClientOptions
             {
                 Domain = Resources.GetString(Resource.String.auth0_domain),
-                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2",
-                Scope = "openid profile email",
+                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2"
             }, this);
 
             SetContentView(Resource.Layout.Main);

--- a/test/UWP/MainPage.xaml.cs
+++ b/test/UWP/MainPage.xaml.cs
@@ -22,8 +22,7 @@ namespace UWPTestApp
             _auth0Client = new Auth0Client(new Auth0ClientOptions
             {
                 Domain = "auth0-dotnet-integration-tests.auth0.com",
-                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2",
-                Scope = "openid profile email"
+                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2"
             });
         }
 

--- a/test/WPF/MainWindow.xaml.cs
+++ b/test/WPF/MainWindow.xaml.cs
@@ -20,8 +20,7 @@ namespace WpfTestApp
             _auth0Client = new Auth0Client(new Auth0ClientOptions
             {
                 Domain = "auth0-dotnet-integration-tests.auth0.com",
-                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2",
-                Scope = "openid profile email"
+                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2"
             });
         }
 

--- a/test/WinForms/MainForm.cs
+++ b/test/WinForms/MainForm.cs
@@ -20,8 +20,7 @@ namespace WindowsFormsTestApp
             _auth0Client = new Auth0Client(new Auth0ClientOptions
             {
                 Domain = "auth0-dotnet-integration-tests.auth0.com",
-                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2",
-                Scope = "openid profile email"
+                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2"
             });
         }
 

--- a/test/iOS/MyViewController.cs
+++ b/test/iOS/MyViewController.cs
@@ -22,8 +22,7 @@ namespace iOSTestApp
             _auth0Client = new Auth0Client(new Auth0ClientOptions
             {
                 Domain = "auth0-dotnet-integration-tests.auth0.com",
-                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2",
-                Scope = "openid profile email"
+                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2"
             });
 
             LoginButton.Clicked += Login;


### PR DESCRIPTION
For better OpenID Connect compliance we are now:

- [x] Defaulting to including `email` in the list of scopes
- [x] Ensuring `openid` is included on requests if overwritten/removed