### PR TITLE
Move ClientSecret to new Auth0ConfidentialClientOptions class to discourage use

### DIFF
--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -113,7 +113,6 @@ namespace Auth0.OidcClient
             {
                 Authority = $"https://{options.Domain}",
                 ClientId = options.ClientId,
-                ClientSecret = options.ClientSecret,
                 Scope = String.Join(" ", scopes),
                 LoadProfile = options.LoadProfile,
                 Browser = options.Browser,
@@ -127,6 +126,11 @@ namespace Auth0.OidcClient
                     RequireAccessTokenHash = false
                 }
             };
+
+#pragma warning disable CS0618 // ClientSecret will be removed in a future update.
+            if (!String.IsNullOrWhiteSpace(oidcClientOptions.ClientSecret))
+                oidcClientOptions.ClientSecret = options.ClientSecret;
+#pragma warning restore CS0618
 
             if (options.RefreshTokenMessageHandler != null)
                 oidcClientOptions.RefreshTokenInnerHttpHandler = options.RefreshTokenMessageHandler;

--- a/src/Auth0.OidcClient.Core/Auth0ClientOptions.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientOptions.cs
@@ -1,4 +1,5 @@
 ﻿using IdentityModel.OidcClient.Browser;
+using System;
 using System.Net.Http;
 
 namespace Auth0.OidcClient
@@ -22,6 +23,8 @@ namespace Auth0.OidcClient
         /// <summary>
         /// Your Auth0 Client Secret.
         /// </summary>
+        [Obsolete("Client Secrets should not be used in non-confidential clients such as native desktop and mobile apps. " +
+            "This property will be removed in a future release.")]
         public string ClientSecret { get; set; }
 
         /// <summary>


### PR DESCRIPTION
Client secrets should not be used in clients unless they are considered confidential. While there might be some use cases where the client application is adequately protected it is not typical.

By moving the `ClientSecret` option to the new `Auth0ConfidentClientOptions` class most new users won't see it and existing users will have to make a conscious decision/evaluation as to whether they continue using it or switch to alternate flows.