### PR TITLE
Ensure a default Browser created on Android when no Activity provided

### DIFF
--- a/src/Auth0.OidcClient.Android/Auth0Client.cs
+++ b/src/Auth0.OidcClient.Android/Auth0Client.cs
@@ -26,6 +26,8 @@ namespace Auth0.OidcClient
         public Auth0Client(Auth0ClientOptions options)
             : base(options, "xamarin-android")
         {
+            options.Browser = options.Browser ?? new AutoSelectBrowser();
+
             var defaultRedirectUri = options.RedirectUri == null || options.PostLogoutRedirectUri == null
                 ? GetConventionCallbackUri(options.Domain) : null;
 


### PR DESCRIPTION
Regression from 2.9.x where default legacy constructor on Android for Auth0Client no longer creates a Browser.  

Fixes #118 