### PR TITLE
Add nuget package deps for WebView & OIDC

### DIFF
--- a/nuget/Auth0.OidcClient.Core.nuspec
+++ b/nuget/Auth0.OidcClient.Core.nuspec
@@ -58,6 +58,7 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="IdentityModel.OidcClient" version="3.0.1" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.5.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.WPF.nuspec
+++ b/nuget/Auth0.OidcClient.WPF.nuspec
@@ -65,6 +65,7 @@
     <dependencies>
       <group targetFramework="net462">
         <dependency id="Auth0.OidcClient.Core" version="3.0.1" />
+        <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="5.1.1"/>
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.WinForms.nuspec
+++ b/nuget/Auth0.OidcClient.WinForms.nuspec
@@ -64,6 +64,7 @@
     <dependencies>
       <group targetFramework="net462">
         <dependency id="Auth0.OidcClient.Core" version="3.0.1" />
+        <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="5.1.1"/>
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Adds package dependencies missing from the nuget definitions to ensure dependencies are auto-installed.

Specifically:

- Microsoft.Toolkit.Forms.UI.Controls.WebView required for Edge compatibility with WPF & WinForms
- Microsoft.IdentityModel.Protocols.OpenIdConnect related to the OIDC Compliance / ID Token work

Fixes #123 