### PR TITLE
Simplify AsymmetricSignatureVerifier

### DIFF
--- a/src/Auth0.OidcClient.Core/Tokens/AsymmetricSignatureVerifier.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/AsymmetricSignatureVerifier.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
-using System.Linq;
 using System.Threading.Tasks;
 
 namespace Auth0.OidcClient.Tokens
@@ -39,12 +38,10 @@ namespace Auth0.OidcClient.Tokens
             if (decoded.SignatureAlgorithm != "RS256")
                 throw new IdTokenValidationException($"Signature algorithm of \"{decoded.Header.Alg }\" is not supported. Expected the ID token to be signed with \"RS256\".");
 
-            var publicKey = FindPublicKeyByKid(decoded.Header.Kid);
-
-            return (JwtSecurityToken) ValidateTokenSignatureWithKey(token, securityTokenHandler, publicKey);
+            return (JwtSecurityToken)ValidateTokenSignature(token, securityTokenHandler, decoded.Header.Kid);
         }
 
-        internal static SecurityToken ValidateTokenSignatureWithKey(string token, JwtSecurityTokenHandler securityTokenHandler, JsonWebKey key)
+        internal SecurityToken ValidateTokenSignature(string token, JwtSecurityTokenHandler securityTokenHandler, string kid)
         {
             try
             {
@@ -58,25 +55,20 @@ namespace Auth0.OidcClient.Tokens
 
                     RequireSignedTokens = true,
                     ValidateIssuerSigningKey = true,
-                    IssuerSigningKey = key,
+                    IssuerSigningKeys = keys,
                 };
 
                 securityTokenHandler.ValidateToken(token, validationParameters, out var verifiedToken);
                 return verifiedToken;
             }
+            catch (SecurityTokenSignatureKeyNotFoundException)
+            {
+                throw new IdTokenValidationException($"Could not find a public key for Key ID (kid) \"{kid}\".");
+            }
             catch (SecurityTokenException e)
             {
                 throw new IdTokenValidationException("Invalid ID token signature.", e);
             }
-        }
-
-        private JsonWebKey FindPublicKeyByKid(string kid)
-        {
-            var key = keys.FirstOrDefault(k => k.Kid == kid);
-            if (key == null)
-                throw new IdTokenValidationException($"Could not find a public key for Key ID (kid) \"{kid}\".");
-
-            return key;
         }
     }
 }


### PR DESCRIPTION
Small simplification of the OIDC Compliance ID Token Validation work started in #117 

Basically ValidateToken is capable of finding the right key itself from a list, no need to pre-filter it out.