### PR TITLE
Bump dependencies

### DIFF
--- a/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
+++ b/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
@@ -67,7 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>3.0.1</Version>
+      <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.CustomTabs">
       <Version>28.0.0.3</Version>

--- a/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
+++ b/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient" Version="3.0.1" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.5.0" />
+    <PackageReference Include="IdentityModel.OidcClient" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
+++ b/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.5.0" />
     <PackageReference Include="IdentityModel.OidcClient" Version="3.1.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.6.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Auth0.OidcClient.UWP/project.json
+++ b/src/Auth0.OidcClient.UWP/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "IdentityModel.OidcClient": "3.0.1",
+    "IdentityModel.OidcClient": "3.1.0",
     "Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
   },
   "frameworks": {

--- a/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
+++ b/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
@@ -89,7 +89,7 @@
       <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Wpf.UI.Controls.WebView">
-      <Version>5.1.1</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
+++ b/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
@@ -86,7 +86,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>3.0.1</Version>
+      <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Wpf.UI.Controls.WebView">
       <Version>5.1.1</Version>

--- a/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
+++ b/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
@@ -66,7 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>3.0.1</Version>
+      <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Forms.UI.Controls.WebView">
       <Version>5.1.1</Version>

--- a/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
+++ b/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
@@ -69,7 +69,7 @@
       <Version>3.1.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.Toolkit.Forms.UI.Controls.WebView">
-      <Version>5.1.1</Version>
+      <Version>6.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
+++ b/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>3.0.1</Version>
+      <Version>3.1.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/test/Android/Android.csproj
+++ b/test/Android/Android.csproj
@@ -88,7 +88,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>3.0.1</Version>
+      <Version>3.1.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
+++ b/test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
+++ b/test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
@@ -8,8 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.collector" Version="1.0.1" />
   </ItemGroup>
 

--- a/test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
+++ b/test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
@@ -13,7 +13,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/UWP/project.json
+++ b/test/UWP/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "IdentityModel.OidcClient": "3.0.1",
+    "IdentityModel.OidcClient": "3.1.0",
     "Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
   },
   "frameworks": {

--- a/test/WPF/WPF.csproj
+++ b/test/WPF/WPF.csproj
@@ -107,7 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>3.0.1</Version>
+      <Version>3.1.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/WinForms/WinForms.csproj
+++ b/test/WinForms/WinForms.csproj
@@ -123,7 +123,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>3.0.1</Version>
+      <Version>3.1.0</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/iOS/iOS.csproj
+++ b/test/iOS/iOS.csproj
@@ -129,7 +129,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient">
-      <Version>3.0.1</Version>
+      <Version>3.1.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- Bump IdentityModel.OidcClient to 3.1.0
- Bump Microsoft.IdentityModel.Protocols.OpenIdConnect to 5.6.0
- Bump xunit to 2.4.1
- Bump Microsoft.NET.Test.Sdk to 16.4.0
- Remove redundant coverlet.collector 
- Bump Microsoft.Toolkit.*.UI.Controls.WebView to 6.0.0