### PR TITLE
Align ID Token Signature validation failure message with other platforms

### DIFF
--- a/src/Auth0.OidcClient.Core/Tokens/AsymmetricSignatureVerifier.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/AsymmetricSignatureVerifier.cs
@@ -67,7 +67,7 @@ namespace Auth0.OidcClient.Tokens
             }
             catch (SecurityTokenException e)
             {
-                throw new IdTokenValidationException("Invalid ID token signature.", e);
+                throw new IdTokenValidationException("Invalid token signature.", e);
             }
         }
     }

--- a/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
+++ b/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
@@ -85,7 +85,7 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
             var signatureVerifier = new AsymmetricSignatureVerifier(signingKeys.Keys);
 
             var ex = await Assert.ThrowsAsync<IdTokenValidationException>(() => ValidateToken(token, signedReqs, new DateTime(2019, 11, 1, 11, 00, 00, DateTimeKind.Utc), signatureVerifier));
-            Assert.Equal("Invalid ID token signature.", ex.Message);
+            Assert.Equal("Invalid token signature.", ex.Message);
         }
 
         [Fact]


### PR DESCRIPTION
In order to align with the other platforms, e.g. https://github.com/auth0/auth0.net/pull/326#discussion_r350246994