### PR TITLE
OpenIdConnect package dep version is now 5.6.0 to align with version …

### DIFF
--- a/nuget/Auth0.OidcClient.Core.nuspec
+++ b/nuget/Auth0.OidcClient.Core.nuspec
@@ -63,7 +63,7 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="IdentityModel.OidcClient" version="3.1.0" />
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.5.0" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.6.0" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
…in Auth0.Client.Core

### Changes

It appears that the versions of the Microsoft.IdentityModel.Protocols.OpenIdConnect package specified in file Auth0.Client.Core.csproj (5.6.0) and file Auth0.OidcClient.Core.nuspec (5.5.0) are out of sync.

This pull request is to align both versions to 5.6.0

### Testing

Generate NuGet package and install into a test project. Check the version of Microsoft.IdentityModel.Protocols.OpenIdConnect in the VS NuGet confirmation prompt lists the library version as 5.6.0

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
