### PR TITLE
Do not close WinForms legacy browser on nav error

### DIFF
--- a/src/Auth0.OidcClient.WinForms/WebBrowserBrowser.cs
+++ b/src/Auth0.OidcClient.WinForms/WebBrowserBrowser.cs
@@ -64,14 +64,6 @@ namespace Auth0.OidcClient
                     signal.Release();
                 };
 
-                browser.NavigateError += (s, e) =>
-                {
-                    e.Cancel = true;
-                    result.ResultType = BrowserResultType.HttpError;
-                    result.Error = e.StatusCode.ToString();
-                    signal.Release();
-                };
-
                 browser.DocumentCompleted += (s, e) =>
                 {
                     if (e.Url.AbsoluteUri.StartsWith(options.EndUrl))

--- a/src/Auth0.OidcClient.WinForms/WebBrowserBrowser.cs
+++ b/src/Auth0.OidcClient.WinForms/WebBrowserBrowser.cs
@@ -64,6 +64,18 @@ namespace Auth0.OidcClient
                     signal.Release();
                 };
 
+                browser.NavigateError += (s, e) =>
+                {
+                    // Windows Server secure browsing requires this
+                    if (e.Url.StartsWith(options.EndUrl))
+                    {
+                        e.Cancel = true;
+                        result.ResultType = BrowserResultType.Success;
+                        result.Response = e.Url;
+                        signal.Release();
+                    }
+                };
+
                 browser.DocumentCompleted += (s, e) =>
                 {
                     if (e.Url.AbsoluteUri.StartsWith(options.EndUrl))


### PR DESCRIPTION
When using the new Universal Login page the server returns 400 series errors when there are problems with the login - e.g. 400 for invalid username password, 401, 403 etc.

The WinForms legacy IE-only `WebBrowserBrowser` implementation would close the window when encountering a navigation error.

Given that none of the other browsers implementations do this and it would be useful to show actual navigation errors in-browser rather than instantly close them down and supply the user with no information it makes sense to just remove this 'feature'.

Also we need to use the same event to close the browser with success if the URL is the final "good" url as corrected in the OIDC Samples https://github.com/IdentityModel/IdentityModel.OidcClient.Samples/blob/master/WinFormsWebView/WinFormsSample/Browser/WinFormsWebView.cs#L57-L61

Fixes #79 