### PR TITLE
WPF-only 3.1.3 strong-named fix

### DIFF
--- a/nuget/Auth0.OidcClient.WPF.nuspec
+++ b/nuget/Auth0.OidcClient.WPF.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.WPF</id>
-    <version>3.1.2</version>
+    <version>3.1.3</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for WPF apps</description>
     <releaseNotes>
+      Version 3.1.3
+      - WPF version is now actually strong-named.
+
       Version 3.1.2
       - Allow ID tokens "issued at" (iat) claims from "the future" to allow
         slow local clocks on mobile and desktop devices.

--- a/src/Auth0.OidcClient.WPF/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.WPF/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Windows;
 
 [assembly: AssemblyTitle("Auth0.OidcClient.WPF")]
 [assembly: AssemblyProduct("Auth0.OidcClient")]
-[assembly: AssemblyVersion("3.1.2")]
-[assembly: AssemblyFileVersion("3.1.2")]
+[assembly: AssemblyVersion("3.1.3")]
+[assembly: AssemblyFileVersion("3.1.3")]
 [assembly: ComVisible(false)]
 
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]


### PR DESCRIPTION
No need to bump the other libraries as nothing changed there.