### PR TITLE
Allow switching back to app for 2FA

### DIFF
--- a/src/Auth0.OidcClient.Android/ChromeCustomTabsBrowser.cs
+++ b/src/Auth0.OidcClient.Android/ChromeCustomTabsBrowser.cs
@@ -23,7 +23,6 @@ namespace Auth0.OidcClient
             using (var builder = new CustomTabsIntent.Builder())
             using (var customTabsIntent = builder.Build())
             {
-                customTabsIntent.Intent.AddFlags(ActivityFlags.NoHistory);
                 if (IsNewTask)
                     customTabsIntent.Intent.AddFlags(ActivityFlags.NewTask);
                 customTabsIntent.LaunchUrl(context, uri);

--- a/src/Auth0.OidcClient.Android/SystemBrowser.cs
+++ b/src/Auth0.OidcClient.Android/SystemBrowser.cs
@@ -21,7 +21,6 @@ namespace Auth0.OidcClient
         protected override void OpenBrowser(Android.Net.Uri uri, Context context = null)
         {
             var intent = new Intent(Intent.ActionView, uri);
-            intent.AddFlags(ActivityFlags.NoHistory);
 
             if (IsNewTask)
                 intent.AddFlags(ActivityFlags.NewTask);


### PR DESCRIPTION
This change modifies the Android project to remove the `ActivityFlags.NoHistory` flag from our intents as they interfere with successfully switching to a 2FA application and back during the flow.

Other platforms are not affected by this behavior and removing or adding the flag on the system browser flow has no effect.