### PR TITLE
Fixed incorrect .NET Core 3.1 dependency in NuGet package

### DIFF
--- a/nuget/Auth0.OidcClient.WPF.nuspec
+++ b/nuget/Auth0.OidcClient.WPF.nuspec
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for WPF apps</description>
     <releaseNotes>
+      Version 3.1.5
+      - Fixed incorrect dependency in .NET Core 3.1 version
+
       Version 3.1.4
       - Now supports .NET Core 3.1 projects
 
@@ -80,7 +83,7 @@
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
-        <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="6.0.0"/>
+        <dependency id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="6.0.0"/>
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
### Changes

Fixed an incorrect dependency in the WPF.nuspec file. 

Package was referencing Microsoft.Toolkit.Forms.UI.Controls.WebView instead of 
Microsoft.Toolkit.Wpf.UI.Controls.WebView

### References

### Testing

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
