### PR TITLE
Fixed nuspec dependency versions

### DIFF
--- a/nuget/Auth0.OidcClient.WPF.nuspec
+++ b/nuget/Auth0.OidcClient.WPF.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.WPF</id>
-    <version>3.1.6</version>
+    <version>3.1.7</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for WPF apps</description>
     <releaseNotes>
+      Version 3.1.7
+      - Fixed dependency version in nuspec file for Microsoft.Toolkit.Wpf.UI.Controls.WebView
+      
       Version 3.1.6
       - Bumped Microsoft.Toolkit.Wpf.UI.Controls.WebView to 6.1.1
 
@@ -82,11 +85,11 @@
     <dependencies>
       <group targetFramework="net462">
         <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
-        <dependency id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="6.0.0"/>
+        <dependency id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="6.1.1"/>
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
-        <dependency id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="6.0.0"/>
+        <dependency id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="6.1.1"/>
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.WinForms.nuspec
+++ b/nuget/Auth0.OidcClient.WinForms.nuspec
@@ -78,11 +78,11 @@
     <dependencies>
       <group targetFramework="net462">
         <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
-        <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="6.0.0"/>
+        <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="6.1.1"/>
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
-        <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="6.0.0"/>
+        <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="6.1.1"/>
       </group>
     </dependencies>
   </metadata>

--- a/src/Auth0.OidcClient.WPF/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.WPF/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Windows;
 
 [assembly: AssemblyTitle("Auth0.OidcClient.WPF")]
 [assembly: AssemblyProduct("Auth0.OidcClient")]
-[assembly: AssemblyVersion("3.1.6")]
-[assembly: AssemblyFileVersion("3.1.6")]
+[assembly: AssemblyVersion("3.1.7")]
+[assembly: AssemblyFileVersion("3.1.7")]
 [assembly: ComVisible(false)]
 
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]


### PR DESCRIPTION
This change corrects the dependency versions in the nuspec file for Microsoft.Toolkit.Wpf.UI.Controls.WebView.

The version for OidcClient.WPF has been bumped again as that had been published before I noticed the error.