### PR TITLE
Correct packaging of AndroidX NuGet

### DIFF
--- a/nuget/Auth0.OidcClient.AndroidX.nuspec
+++ b/nuget/Auth0.OidcClient.AndroidX.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.AndroidX</id>
-    <version>3.1.5</version>
+    <version>3.1.6</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Xamarin AndroidX apps</description>
     <releaseNotes>
+      Version 3.1.6
+	  - Correct packaging so the NuGet actually is AndroidX
+	  
       Version 3.1.5
 	  - New version of Auth0.OidcClient.Android targeting AndroidX
     </releaseNotes>
@@ -24,8 +27,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\src\Auth0.OidcClient.Android\bin\Release\Auth0.OidcClient.dll" target="lib\MonoAndroid10" />
-    <file src="..\src\Auth0.OidcClient.Android\bin\Release\Auth0.OidcClient.xml" target="lib\MonoAndroid10" />
+    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\Auth0.OidcClient.dll" target="lib\MonoAndroid10" />
+    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\Auth0.OidcClient.xml" target="lib\MonoAndroid10" />
     <file src="..\build\Auth0Icon.png" />
   </files>
 </package>


### PR DESCRIPTION
Updated the AndroidX nuget package to include the correct binaries for AndroidX (was including pre-X binaries by mistake)

Fixes #143