### PR TITLE
Update AndroidX assembly version to 3.1.6

### DIFF
--- a/src/Auth0.OidcClient.AndroidX/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.AndroidX/Properties/AssemblyInfo.cs
@@ -3,6 +3,6 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Auth0.OidcClient.AndroidX")]
 [assembly: AssemblyProduct("Auth0.OidcClient")]
-[assembly: AssemblyVersion("3.1.5")]
-[assembly: AssemblyFileVersion("3.1.5")]
+[assembly: AssemblyVersion("3.1.6")]
+[assembly: AssemblyFileVersion("3.1.6")]
 [assembly: ComVisible(false)]


### PR DESCRIPTION
Forgot to bump the AssemblyInfo.cs for AndroidX to 3.1.6 which needs to be done before publishing to NuGet.