### PR TITLE
[SDK-1978] Update docs to use Edge compatible callback URL

### DIFF
--- a/docs-source/documentation/getting-started/callbacks.md
+++ b/docs-source/documentation/getting-started/callbacks.md
@@ -10,28 +10,16 @@ The format of the URL will depend on the platform. In the sample callback URLs b
 
 ## Universal Windows Platform (UWP)
 
-For UWP applications, the callback URL needs to be in the format **ms-app://SID**, where **SID** is the **Package SID** for your application. Assuming you have associated your application with and application on the Windows Store, you can go to the Windows Developer Centre, go to the settings for your application, and then go to the App management > App identity section, where you will see the **Package SID** listed.
+Use the following callback URL:
 
-Alternatively - or if you have not associated your application with the Store yet - you can obtain the value by calling the `Windows.Security.Authentication.Web.WebAuthenticationBroker.GetCurrentApplicationCallbackUri()` method. So for example, in the `OnLaunched` method of your application, you can add the following line of code:
-
-```csharp
-protected override void OnLaunched(LaunchActivatedEventArgs e)
-{
-#if DEBUG
-    if (System.Diagnostics.Debugger.IsAttached)
-    {
-        System.Diagnostics.Debug.WriteLine(Windows.Security.Authentication.Web.WebAuthenticationBroker.GetCurrentApplicationCallbackUri());
-    }
-#endif
-    
-    // rest of code omitted for brevity
-}
+```text
+https://YOUR_AUTH0_DOMAIN/mobile
 ```
 
 For example:
 
 ```text
-ms-app://S-1-11-1-1111111111-2222222222-3333333333-4444444444-5555555555-6666666666-7777777777
+https://contoso.auth0.com/mobile
 ```
 
 ## Windows Presentation Foundation (WPF)

--- a/docs/documentation/getting-started/callbacks.html
+++ b/docs/documentation/getting-started/callbacks.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <!--[if IE]><![endif]-->
 <html>
   
@@ -74,21 +74,10 @@
 <p>The format of the URL will depend on the platform. In the sample callback URLs below, replace <code>YOUR_AUTH0_DOMAIN</code> with your actual Auth0 domain. You can find your domain on the Settings tab for your Client inside the <a href="https://manage.auth0.com/#/">Auth0 dashboard</a>: </p>
 <p><img src="/images/dashboard-domain.png" alt=""></p>
 <h2 id="universal-windows-platform-uwp">Universal Windows Platform (UWP)</h2>
-<p>For UWP applications, the callback URL needs to be in the format <strong>ms-app://SID</strong>, where <strong>SID</strong> is the <strong>Package SID</strong> for your application. Assuming you have associated your application with and application on the Windows Store, you can go to the Windows Developer Centre, go to the settings for your application, and then go to the App management &gt; App identity section, where you will see the <strong>Package SID</strong> listed.</p>
-<p>Alternatively - or if you have not associated your application with the Store yet - you can obtain the value by calling the <code>Windows.Security.Authentication.Web.WebAuthenticationBroker.GetCurrentApplicationCallbackUri()</code> method. So for example, in the <code>OnLaunched</code> method of your application, you can add the following line of code:</p>
-<pre><code class="lang-csharp">protected override void OnLaunched(LaunchActivatedEventArgs e)
-{
-#if DEBUG
-    if (System.Diagnostics.Debugger.IsAttached)
-    {
-        System.Diagnostics.Debug.WriteLine(Windows.Security.Authentication.Web.WebAuthenticationBroker.GetCurrentApplicationCallbackUri());
-    }
-#endif
-
-    // rest of code omitted for brevity
-}
+<p>Use the following callback URL:</p>
+<pre><code class="lang-text">https://YOUR_AUTH0_DOMAIN/mobile
 </code></pre><p>For example:</p>
-<pre><code class="lang-text">ms-app://S-1-11-1-1111111111-2222222222-3333333333-4444444444-5555555555-6666666666-7777777777
+<pre><code class="lang-text">https://contoso.auth0.com/mobile
 </code></pre><h2 id="windows-presentation-foundation-wpf">Windows Presentation Foundation (WPF)</h2>
 <p>Use the following callback URL:</p>
 <pre><code class="lang-text">https://YOUR_AUTH0_DOMAIN/mobile


### PR DESCRIPTION
### Changes

A while ago support for Edge has been added which changed the way redirectUri is built: https://github.com/auth0/auth0-oidc-client-net/commit/5821130421447aad74facde6395f4e814003edd1

The docs havent been updated accordingly.

This PR updates the docs.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
