### PR TITLE
Fix WPF web viewer is not properly closed

### DIFF
--- a/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
@@ -52,7 +52,7 @@ namespace Auth0.OidcClient
             var webView = new WebViewCompatible();
             window.Content = webView;
 
-            webView.NavigationStarting += (sender, e) =>
+            webView.NavigationCompleted += (sender, e) =>
             {
                 if (e.Uri.AbsoluteUri.StartsWith(options.EndUrl))
                 {
@@ -66,6 +66,7 @@ namespace Auth0.OidcClient
 
             window.Closing += (sender, e) =>
             {
+                webView.Dispose();
                 if (!tcs.Task.IsCompleted)
                     tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.UserCancel });
             };

--- a/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
@@ -52,7 +52,7 @@ namespace Auth0.OidcClient
             var webView = new WebViewCompatible();
             window.Content = webView;
 
-            webView.NavigationCompleted += (sender, e) =>
+            webView.NavigationStarting += (sender, e) =>
             {
                 if (e.Uri.AbsoluteUri.StartsWith(options.EndUrl))
                 {


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

Changed the behavior of the `WebViewBrowser` class to close the window on `NavigationCompleted` event and manually dispose the web view control when the window is closed.

### References
https://github.com/auth0/auth0-oidc-client-net/issues/170

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
