### PR TITLE
[SDK-2197] Support for PrefersEphemeralWebBrowserSession

### DIFF
--- a/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
@@ -12,13 +12,27 @@ namespace Auth0.OidcClient
     /// </summary>
     public class ASWebAuthenticationSessionBrowser : IOSBrowserBase
     {
+        /// <summary>
+        /// Configuration for the ASWebAuthenticationSession.
+        /// </summary>
+        public ASWebAuthenticationSessionOptions SessionOptions { get; }
+
+        /// <summary>
+        /// Creates a new instance of the ASWebAuthenticationSession Browser.
+        /// </summary>
+        /// <param name="sessionOptions">The <see cref="ASWebAuthenticationSessionOptions"/> specifying the configuration for the ASWebAuthenticationSession.</param>
+        public ASWebAuthenticationSessionBrowser(ASWebAuthenticationSessionOptions sessionOptions = null)
+        {
+            SessionOptions = sessionOptions;
+        }
+
         /// <inheritdoc/>
         protected override Task<BrowserResult> Launch(BrowserOptions options, CancellationToken cancellationToken = default)
         {
-            return Start(options);
+            return Start(options, SessionOptions);
         }
 
-        internal static Task<BrowserResult> Start(BrowserOptions options)
+        internal static Task<BrowserResult> Start(BrowserOptions options, ASWebAuthenticationSessionOptions sessionOptions = null)
         {
             var tcs = new TaskCompletionSource<BrowserResult>();
 
@@ -34,7 +48,10 @@ namespace Auth0.OidcClient
 
             // iOS 13 requires the PresentationContextProvider set
             if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
+            {
                 asWebAuthenticationSession.PresentationContextProvider = new PresentationContextProviderToSharedKeyWindow();
+                asWebAuthenticationSession.PrefersEphemeralWebBrowserSession = sessionOptions != null ? sessionOptions.PrefersEphemeralWebBrowserSession : false;
+            }
 
             asWebAuthenticationSession.Start();
 

--- a/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
@@ -63,10 +63,11 @@ namespace Auth0.OidcClient
                     asWebAuthenticationSession.Dispose();
                 });
 
-            // iOS 13 requires the PresentationContextProvider set
             if (UIDevice.CurrentDevice.CheckSystemVersion(13, 0))
             {
+                // iOS 13 requires the PresentationContextProvider set
                 asWebAuthenticationSession.PresentationContextProvider = new PresentationContextProviderToSharedKeyWindow();
+                // PrefersEphemeralWebBrowserSession is only available on iOS 13 and up.
                 asWebAuthenticationSession.PrefersEphemeralWebBrowserSession = sessionOptions != null ? sessionOptions.PrefersEphemeralWebBrowserSession : false;
             }
 

--- a/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
@@ -21,6 +21,23 @@ namespace Auth0.OidcClient
         /// Creates a new instance of the ASWebAuthenticationSession Browser.
         /// </summary>
         /// <param name="sessionOptions">The <see cref="ASWebAuthenticationSessionOptions"/> specifying the configuration for the ASWebAuthenticationSession.</param>
+        /// <example>
+        /// If any custom browser configuration is needed (e.g. using <see cref="ASWebAuthenticationSessionOptions.PrefersEphemeralWebBrowserSession"/>), 
+        /// a new browser instance should be instantiated and passed to <see cref="Auth0ClientOptions.Browser"/>.
+        /// <code>
+        /// var client = new Auth0Client(new Auth0ClientOptions
+        /// {
+        ///   Domain = "YOUR_AUTH0_DOMAIN",
+        ///   ClientId = "YOUR_AUTH0_CLIENT_ID",
+        ///   Browser = new ASWebAuthenticationSessionBrowser(
+        ///     new ASWebAuthenticationSessionOptions
+        ///     {
+        ///       PrefersEphemeralWebBrowserSession = true
+        ///     }
+        ///   )
+        /// });
+        /// </code>
+        /// </example>
         public ASWebAuthenticationSessionBrowser(ASWebAuthenticationSessionOptions sessionOptions = null)
         {
             SessionOptions = sessionOptions;

--- a/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionOptions.cs
+++ b/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionOptions.cs
@@ -1,0 +1,13 @@
+﻿namespace Auth0.OidcClient
+{
+    /// <summary>
+    /// Specifies options that can be passed to <see cref="ASWebAuthenticationSessionBrowser"/> implementations.
+    /// </summary>
+    public class ASWebAuthenticationSessionOptions
+    {
+        /// <summary>
+        /// Specify whether or not EphemeralWebBrowserSessions should be preferred.
+        /// </summary>
+        public bool PrefersEphemeralWebBrowserSession { get; set; }
+    }
+}

--- a/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionOptions.cs
+++ b/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionOptions.cs
@@ -6,7 +6,7 @@
     public class ASWebAuthenticationSessionOptions
     {
         /// <summary>
-        /// Specify whether or not EphemeralWebBrowserSessions should be preferred.
+        /// Specify whether or not EphemeralWebBrowserSessions should be preferred. Defaults to false.
         /// </summary>
         public bool PrefersEphemeralWebBrowserSession { get; set; }
     }

--- a/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionOptions.cs
+++ b/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionOptions.cs
@@ -8,6 +8,10 @@
         /// <summary>
         /// Specify whether or not EphemeralWebBrowserSessions should be preferred. Defaults to false.
         /// </summary>
+        /// <remarks>
+        /// Setting <see cref="PrefersEphemeralWebBrowserSession"/> to true will disable <see href="https://auth0.com/docs/sso">Single Sign On (SSO)</see> on iOS 13+.
+        /// As a consequence of that, it will also prevent from showing the popup that's being used to ask consent for using Auth0 to sign in.
+        /// </remarks>
         public bool PrefersEphemeralWebBrowserSession { get; set; }
     }
 }

--- a/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
+++ b/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
@@ -50,6 +50,7 @@
     <Compile Include="IOSBrowserBase.cs" />
     <Compile Include="Auth0Client.cs" />
     <Compile Include="ASWebAuthenticationSessionBrowser.cs" />
+    <Compile Include="ASWebAuthenticationSessionOptions.cs" />
     <Compile Include="SFAuthenticationSessionBrowser.cs" />
     <Compile Include="SFSafariViewControllerBrowser.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/test/iOS/MyViewController.cs
+++ b/test/iOS/MyViewController.cs
@@ -22,8 +22,13 @@ namespace iOSTestApp
             _auth0Client = new Auth0Client(new Auth0ClientOptions
             {
                 Domain = "auth0-dotnet-integration-tests.auth0.com",
-                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2"
-            });
+                ClientId = "qmss9A66stPWTOXjR6X1OeA0DLadoNP2",
+                // Optional.
+                // The SDK will determine which browser to use when omitted.
+                // In case you need to specify custom browser configuration,
+                // you should create a new Browser instance and provide it with the corresponding options.
+                Browser = new ASWebAuthenticationSessionBrowser(new ASWebAuthenticationSessionOptions { PrefersEphemeralWebBrowserSession = false })
+            }) ;
 
             LoginButton.Clicked += Login;
             UserInfoButton.Clicked += UserInfo;


### PR DESCRIPTION
### Changes

This PR adds in support for `Ephemeral Sessions` on iOS when using `ASWebAuthenticationSessionBrowser` (used by default on iOS 12+).

In order to use custom browser configuration, the users should manually create the browser and pass it the correct properties.
```
var client = new Auth0Client(new Auth0ClientOptions
 {
    Domain = "YOUR_AUTH0_DOMAIN",
    ClientId = "YOUR_AUTH0_CLIENT_ID",
    Browser = new ASWebAuthenticationSessionBrowser(
        new ASWebAuthenticationSessionOptions
        {
           PrefersEphemeralWebBrowserSession = true
        }
    )
});
```

One of the consequences of using `Ephemeral Sessions` is that it will no longer prompt with the message described in https://github.com/auth0/auth0-oidc-client-net/issues/166.

### References

https://github.com/auth0/auth0-oidc-client-net/issues/157

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
