### PR TITLE
[SDK-2293] Do not handle NavigationFailed in order to support the new Universal Login Page

### DIFF
--- a/src/Auth0.OidcClient.UWP/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.UWP/WebViewBrowser.cs
@@ -56,12 +56,6 @@ namespace Auth0.OidcClient
                 }
             };
 
-            webView.NavigationFailed += (sender, e) =>
-            {
-                tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.UnknownError, Error = e.WebErrorStatus.ToString() });
-                window.Close();
-            };
-
             // There is no closed event so the best we can do is detect visibility. This means we close when they minimize too.
             window.VisibilityChanged += (sender, e) =>
             {


### PR DESCRIPTION
The **new Universal Login Page** does not use JavaScript. So instead of doing an xHR call when entering credentials, it will do a regular from post , returning a 400 when entering incorrect credentials and handle the 400 request by showing the appropriate message. As this involves a postback, this will get caught by our UWP's `NavigationFailed` handler (see: https://github.com/auth0/auth0-oidc-client-net/blob/master/src/Auth0.OidcClient.UWP/WebViewBrowser.cs#L59-L63)

```
webView.NavigationFailed += (sender, e) =>
{
    tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.UnknownError, Error = e.WebErrorStatus.ToString() });
    window.Close();
};
```

In the case of entering wrong credentials, all `e.WebErrorStatus.ToString()` is giving the user is `BadRequest`. We are closing the browser for no reason as it confuses the user more than seeing the actual error on the new Universal Login Page.

This brings the question: Should we even close the browser in case any error occurs? My guess is here that the ULP will most likely give the user more information. 

When there is a configuration issue, auth0 will also show a page notifying the user about that (missing callback URL etc).
Currently, both when using the classic and new ULP, when the callback URL is not configured correctly, the user will not see the Auth0 error page, instead the browser closes with  `e.WebErrorStatus.ToString()` set to `forbidden`, which is the only information we can give the developer / user in that case. Not closing the browser would have given more information to the user.

### Changes

This PR ensures the Browser instance, used for the UWP `Auth0Client`, does not handle the `NavigationFailed` event. This is in line with other Browsers, such as our WPF and Winform alternative. 

Compare our [UWP Browser](https://github.com/auth0/auth0-oidc-client-net/blob/master/src/Auth0.OidcClient.UWP/WebViewBrowser.cs#L50-L73) with our [WPF browser](https://github.com/auth0/auth0-oidc-client-net/blob/master/src/Auth0.OidcClient.WPF/WebViewBrowser.cs#L55-L72) for example.

Changing this behavior can be considered a breaking change. However, I think the situations where NavigationFailed is called and removing the actual error from the screen by closing the browser, arent really expected situations and I would argue it is acceptable to release this as a patch version instead.

I can not think of a single valid situation where we want to automatically close the browser, other than successful authentication and the situation where a user does not give their consent. Both of these use cases still close the browser and redirect to the application for it to handle that, both of them do not involve `NavigationFailed`.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
