### PR TITLE
[SDK-2399] Add support for Organizations

### DIFF
--- a/docs-source/documentation/getting-started/authentication.md
+++ b/docs-source/documentation/getting-started/authentication.md
@@ -193,3 +193,43 @@ if (!loginResult.IsError) {
 }
 ```
 
+## Organizations (Closed Beta)
+
+Organizations is a set of features that provide better support for developers who build and maintain SaaS and Business-to-Business (B2B) applications.
+
+Using Organizations, you can:
+
+- Represent teams, business customers, partner companies, or any logical grouping of users that should have different ways of accessing your applications, as organizations.
+
+- Manage their membership in a variety of ways, including user invitation.
+
+- Configure branded, federated login flows for each organization.
+
+- Implement role-based access control, such that users can have different roles when authenticating in the context of different organizations.
+
+- Build administration capabilities into your products, using Organizations APIs, so that those businesses can manage their own organizations.
+
+Note that Organizations is currently only available to customers on our Enterprise and Startup subscription plans.
+
+### Log in to an organization
+
+Log in to an organization by specifying the `organization` parameter when calling `LoginAsync`:
+
+```csharp
+var loginResult = await client.LoginAsync(new { organization = "YOUR_ORGANIZATION_ID" });
+```
+
+## Accept user invitations
+
+Accept a user invitation by specifying the `invitation` parameter when calling `LoginAsync`:
+
+```csharp
+var loginResult = await client.LoginAsync(new 
+{
+    organization = "YOUR_ORGANIZATION_ID",
+    invitation = "YOUR_INVITATION_ID" 
+});
+```
+
+> [!Note]
+> The `invitation` parameter can be extracted from the invitation URL users receive in their invitation email. 

--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -59,7 +59,14 @@ namespace Auth0.OidcClient
             var result = await OidcClient.LoginAsync(loginRequest, cancellationToken);
 
             if (!result.IsError)
+            {
+                if (finalExtraParameters.ContainsKey("organization"))
+                {
+                    _idTokenRequirements.Organization = finalExtraParameters["organization"];
+                }
+
                 await IdTokenValidator.AssertTokenMeetsRequirements(_idTokenRequirements, result.IdentityToken); // Nonce is created & tested by OidcClient
+            }
 
             return result;
         }
@@ -104,10 +111,18 @@ namespace Auth0.OidcClient
         /// <inheritdoc/>
         public async Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, object extraParameters = null, CancellationToken cancellationToken = default)
         {
-            var result = await OidcClient.RefreshTokenAsync(refreshToken, AppendTelemetry(extraParameters), cancellationToken);
+            var finalExtraParameters = AppendTelemetry(extraParameters);
+            var result = await OidcClient.RefreshTokenAsync(refreshToken, finalExtraParameters, cancellationToken);
 
             if (!result.IsError)
+            {
+                if (finalExtraParameters.ContainsKey("Organization"))
+                {
+                    _idTokenRequirements.Organization = finalExtraParameters["Organization"];
+                }
+
                 await IdTokenValidator.AssertTokenMeetsRequirements(_idTokenRequirements, result.IdentityToken); // Nonce is created & tested by OidcClient
+            }
 
             return result;
         }

--- a/src/Auth0.OidcClient.Core/Tokens/Auth0ClaimNames.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/Auth0ClaimNames.cs
@@ -1,0 +1,11 @@
+﻿namespace Auth0.OidcClient.Tokens
+{
+        /// <summary>
+        /// List of Auth0 specific claims
+        /// </summary>
+        internal static class Auth0ClaimNames
+        {
+            internal static string Organization = "org_id";
+        }
+    
+}

--- a/src/Auth0.OidcClient.Core/Tokens/IdTokenRequirements.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/IdTokenRequirements.cs
@@ -34,6 +34,11 @@ namespace Auth0.OidcClient.Tokens
         public TimeSpan Leeway;
 
         /// <summary>
+        /// Required organization the token must be for.
+        /// </summary>
+        public string Organization;
+
+        /// <summary>
         /// Create a new instance of <see cref="IdTokenRequirements"/> with specified parameters.
         /// </summary>
         /// <param name="issuer">Required issuer (iss) the token must be from.</param>
@@ -41,12 +46,13 @@ namespace Auth0.OidcClient.Tokens
         /// <param name="leeway">Amount of leeway in validating date and time claims to allow some clock variance
         /// between the issuer and the application.</param>
         /// <param name="maxAge">Optional maximum time since the user last authenticated.</param>
-        public IdTokenRequirements(string issuer, string audience, TimeSpan leeway, TimeSpan ? maxAge = null)
+        public IdTokenRequirements(string issuer, string audience, TimeSpan leeway, TimeSpan ? maxAge = null, string organization = null)
         {
             Issuer = issuer;
             Audience = audience;
             Leeway = leeway;
             MaxAge = maxAge;
+            Organization = organization;
         }
     }
 }

--- a/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
@@ -135,11 +135,11 @@ namespace Auth0.OidcClient.Tokens
             // Organization
             if (required.Organization != null)
             {
-                var organizationClaimValue = token.Claims.SingleOrDefault(c => c.Type == "org_id")?.Value;
-                if (string.IsNullOrWhiteSpace(organizationClaimValue))
+                var organization = GetClaimValue(token.Claims, Auth0ClaimNames.Organization);
+                if (string.IsNullOrWhiteSpace(organization))
                     throw new IdTokenValidationException("Organization claim must be a string present in the ID token.");
-                if (organizationClaimValue != required.Organization)
-                    throw new IdTokenValidationException($"Organization claim mismatch in the ID token; expected \"{required.Organization}\", found \"{organizationClaimValue}\".");
+                if (organization != required.Organization)
+                    throw new IdTokenValidationException($"Organization claim mismatch in the ID token; expected \"{required.Organization}\", found \"{organization}\".");
             }
         }
 
@@ -155,6 +155,20 @@ namespace Auth0.OidcClient.Tokens
             if (claim == null) return null;
 
             return (long)Convert.ToDouble(claim.Value, CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Get the value for a given claim.
+        /// </summary>
+        /// <param name="claims"><see cref="IEnumerable{Claim}"/>Claims to search the <paramref name="claimType"/> for.</param>
+        /// <param name="claimType">Type of claim to search the <paramref name="claims"/> for. See <see cref="JwtRegisteredClaimNames"/> or <see cref="Auth0ClaimNames"/> for possible names.</param>
+        /// <returns><see cref="string"/> containing the value or <see langword="null"/> if no matching value was found.</returns>
+        private static string GetClaimValue(IEnumerable<Claim> claims, string claimType)
+        {
+            var claim = claims.SingleOrDefault(t => t.Type == claimType);
+            if (claim == null) return null;
+
+            return claim.Value;
         }
     }
 }

--- a/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
@@ -131,6 +131,16 @@ namespace Auth0.OidcClient.Tokens
                 if (epochNow > authValidUntil)
                     throw new IdTokenValidationException($"Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time ({epochNow}) is after last auth at {authValidUntil}.");
             }
+
+            // Organization
+            if (required.Organization != null)
+            {
+                var organizationClaimValue = token.Claims.SingleOrDefault(c => c.Type == "org_id")?.Value;
+                if (string.IsNullOrWhiteSpace(organizationClaimValue))
+                    throw new IdTokenValidationException("Organization claim must be a string present in the ID token.");
+                if (organizationClaimValue != required.Organization)
+                    throw new IdTokenValidationException($"Organization claim mismatch in the ID token; expected \"{required.Organization}\", found \"{organizationClaimValue}\".");
+            }
         }
 
         /// <summary>

--- a/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
@@ -133,7 +133,7 @@ namespace Auth0.OidcClient.Tokens
             }
 
             // Organization
-            if (required.Organization != null)
+            if (!string.IsNullOrWhiteSpace(required.Organization))
             {
                 var organization = GetClaimValue(token.Claims, Auth0ClaimNames.Organization);
                 if (string.IsNullOrWhiteSpace(organization))

--- a/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
+++ b/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
@@ -244,5 +244,40 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
             var ex = await Assert.ThrowsAsync<IdTokenValidationException>(() => ValidateToken(token));
             Assert.Equal("Authentication Time (auth_time) claim in the ID token indicates that too much time has passed since the last end-user authentication. Current time (1568023200) is after last auth at 1568008254.", ex.Message);
         }
+
+        [Fact]
+        public async void ThrowsWhenOrgIdMissing()
+        {
+            var token = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJleHAiOjE1NjgxODA4OTQuMjI0LCJpYXQiOjE1NjgwMDgwOTQuMjI0LCJub25jZSI6ImExYjJjM2Q0ZTUiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1NjgwOTQ0OTQuMjI0fQ.GXXSBhSUQX8EpWbjAzeL42c-5u76JMUq6clhA_yG9WY";
+
+            var ex = await Assert.ThrowsAsync<IdTokenValidationException>(() => ValidateToken(token, new IdTokenRequirements("https://tokens-test.auth0.com/", "tokens-test-123", TimeSpan.FromMinutes(1))
+            {
+                Nonce = "a1b2c3d4e5",
+                MaxAge = TimeSpan.FromSeconds(100),
+                Organization = "123"
+            }));
+            Assert.Equal("Organization claim must be a string present in the ID token.", ex.Message);
+        }
+
+        [Fact]
+        public async void DoesNotThrowWhenOrgIdAvailable()
+        {
+            var token = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJleHAiOjE1NjgxODA4OTQuMjI0LCJpYXQiOjE1NjgwMDgwOTQuMjI0LCJub25jZSI6ImExYjJjM2Q0ZTUiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1NjgwOTQ0OTQuMjI0LCJvcmdfaWQiOiIxMjMifQ.AsGzG0MWXzd4v-XmIN_7Elgd527jOARv7ChDECH9qUw";
+
+            await ValidateToken(token, new IdTokenRequirements("https://tokens-test.auth0.com/", "tokens-test-123", TimeSpan.FromMinutes(1))
+            {
+                Nonce = "a1b2c3d4e5",
+                MaxAge = TimeSpan.FromSeconds(100),
+                Organization = "123"
+            });
+        }
+
+        [Fact]
+        public async void DoesNotThrowWhenOrgIdAvailableButNotARequirement()
+        {
+            var token = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJleHAiOjE1NjgxODA4OTQuMjI0LCJpYXQiOjE1NjgwMDgwOTQuMjI0LCJub25jZSI6ImExYjJjM2Q0ZTUiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1NjgwOTQ0OTQuMjI0LCJvcmdfaWQiOiIxMjMifQ.AsGzG0MWXzd4v-XmIN_7Elgd527jOARv7ChDECH9qUw";
+
+            await ValidateToken(token);
+        }
     }
 }

--- a/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
+++ b/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
@@ -273,6 +273,21 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
         }
 
         [Fact]
+        public async void ThrowsWhenOrgIdAvailableButDoesntMatch()
+        {
+            var token = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJleHAiOjE1NjgxODA4OTQuMjI0LCJpYXQiOjE1NjgwMDgwOTQuMjI0LCJub25jZSI6ImExYjJjM2Q0ZTUiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1NjgwOTQ0OTQuMjI0LCJvcmdfaWQiOiIxMjMifQ.AsGzG0MWXzd4v-XmIN_7Elgd527jOARv7ChDECH9qUw";
+
+            var ex = await Assert.ThrowsAsync<IdTokenValidationException>(() => ValidateToken(token, new IdTokenRequirements("https://tokens-test.auth0.com/", "tokens-test-123", TimeSpan.FromMinutes(1))
+            {
+                Nonce = "a1b2c3d4e5",
+                MaxAge = TimeSpan.FromSeconds(100),
+                Organization = "1234"
+            }));
+
+            Assert.Equal($"Organization claim mismatch in the ID token; expected \"1234\", found \"123\".", ex.Message);
+        }
+
+        [Fact]
         public async void DoesNotThrowWhenOrgIdAvailableButNotARequirement()
         {
             var token = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJleHAiOjE1NjgxODA4OTQuMjI0LCJpYXQiOjE1NjgwMDgwOTQuMjI0LCJub25jZSI6ImExYjJjM2Q0ZTUiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1NjgwOTQ0OTQuMjI0LCJvcmdfaWQiOiIxMjMifQ.AsGzG0MWXzd4v-XmIN_7Elgd527jOARv7ChDECH9qUw";

--- a/test/WPF/MainWindow.xaml.cs
+++ b/test/WPF/MainWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Windows;
 using Auth0.OidcClient;
 
@@ -29,7 +29,7 @@ namespace WpfTestApp
             clearText();
             writeLine("Starting login...");
 
-            var loginResult = await _auth0Client.LoginAsync();
+            var loginResult = await _auth0Client.LoginAsync( new { organization = "" });
 
             if (loginResult.IsError)
             {


### PR DESCRIPTION
This PR adds support for Organizations as well as User Invitation (even tho limited because of the nature of how User Invitations works currently and how that makes integrating it in Mobile and Desktop applications troublesome)

- Users can pass `organization` and `invitation` parameters to `LoginAsync`, this will send those parameters to the `/authorize` endpoint. Note, we have no first-class support
- The `org_id` claim is validated, only when it was provided to `LoginAsync`.
- The `org_id` claim is parsed and made available as part of `User.Claims`
- Added documentation on how the user can log in to an organization
- Added limited documentation on how the user can accept an invitation, mainly because user invitation is URL based and it's not an easy task to integrate this with WPF, Winforms or UWP and it can also be tricky integrating it with Android or iOS apps.