### PR TITLE
Fix System.Text.Encodings.Web vulnerability

### DIFF
--- a/nuget/Auth0.OidcClient.Android.nuspec
+++ b/nuget/Auth0.OidcClient.Android.nuspec
@@ -92,7 +92,7 @@
     <tags>Auth0 OIDC Android Xamarin</tags>
     <dependencies>
       <group targetFramework="MonoAndroid10">
-        <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
+        <dependency id="Auth0.OidcClient.Core" version="3.2.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.AndroidX.nuspec
+++ b/nuget/Auth0.OidcClient.AndroidX.nuspec
@@ -25,7 +25,7 @@
     <tags>Auth0 OIDC Android Xamarin</tags>
     <dependencies>
       <group targetFramework="MonoAndroid10">
-        <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
+        <dependency id="Auth0.OidcClient.Core" version="3.2.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.Core.nuspec
+++ b/nuget/Auth0.OidcClient.Core.nuspec
@@ -65,6 +65,7 @@
       <group targetFramework="netstandard2.0">
         <dependency id="IdentityModel.OidcClient" version="3.1.2" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.6.0" />
+        <dependency id="System.Text.Encodings.Web" version="4.5.1" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.UWP.nuspec
+++ b/nuget/Auth0.OidcClient.UWP.nuspec
@@ -74,7 +74,7 @@
     <tags>Auth0 OIDC UWP Windows10</tags>
     <dependencies>
       <group targetFramework="uap10.0.16299">
-        <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
+        <dependency id="Auth0.OidcClient.Core" version="3.2.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.WPF.nuspec
+++ b/nuget/Auth0.OidcClient.WPF.nuspec
@@ -90,11 +90,11 @@
     <tags>Auth0 OIDC WPF</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
+        <dependency id="Auth0.OidcClient.Core" version="3.2.0" />
         <dependency id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="6.1.1"/>
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
+        <dependency id="Auth0.OidcClient.Core" version="3.2.0" />
         <dependency id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="6.1.1"/>
       </group>
     </dependencies>

--- a/nuget/Auth0.OidcClient.WinForms.nuspec
+++ b/nuget/Auth0.OidcClient.WinForms.nuspec
@@ -80,11 +80,11 @@
     <tags>Auth0 OIDC WinForms</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
+        <dependency id="Auth0.OidcClient.Core" version="3.2.0" />
         <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="6.1.1"/>
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
+        <dependency id="Auth0.OidcClient.Core" version="3.2.0" />
         <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="6.1.1"/>
       </group>
     </dependencies>

--- a/nuget/Auth0.OidcClient.iOS.nuspec
+++ b/nuget/Auth0.OidcClient.iOS.nuspec
@@ -73,7 +73,7 @@
     <tags>Auth0 OIDC iOS Xamarin</tags>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
-        <dependency id="Auth0.OidcClient.Core" version="3.1.2" />
+        <dependency id="Auth0.OidcClient.Core" version="3.2.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
+++ b/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
@@ -67,6 +67,9 @@
     <PackageReference Include="IdentityModel.OidcClient">
       <Version>3.1.2</Version>
     </PackageReference>
+    <PackageReference Include="System.Text.Encodings.Web">
+      <Version>4.5.1</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.CustomTabs">
       <Version>28.0.0.3</Version>
     </PackageReference>

--- a/src/Auth0.OidcClient.AndroidX/Auth0.OidcClient.AndroidX.csproj
+++ b/src/Auth0.OidcClient.AndroidX/Auth0.OidcClient.AndroidX.csproj
@@ -67,6 +67,9 @@
     <PackageReference Include="IdentityModel.OidcClient">
       <Version>3.1.2</Version>
     </PackageReference>
+    <PackageReference Include="System.Text.Encodings.Web">
+      <Version>4.5.1</Version>
+    </PackageReference>
     <PackageReference Include="Xamarin.AndroidX.Browser">
       <Version>1.0.0</Version>
     </PackageReference>

--- a/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
+++ b/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
@@ -13,6 +13,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient" Version="3.1.2" />
+    <PackageReference Include="System.Text.Encodings.Web">
+      <Version>4.5.1</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="5.6.0" />
   </ItemGroup>
 </Project>

--- a/src/Auth0.OidcClient.UWP/project.json
+++ b/src/Auth0.OidcClient.UWP/project.json
@@ -1,7 +1,8 @@
 ﻿{
   "dependencies": {
     "IdentityModel.OidcClient": "3.1.2",
-    "Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9"
+    "Microsoft.NETCore.UniversalWindowsPlatform": "6.2.9",
+    "System.Text.Encodings.Web": "4.5.1"
   },
   "frameworks": {
     "uap10.0.16299": {}

--- a/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
+++ b/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
@@ -28,6 +28,9 @@
     <PackageReference Include="IdentityModel.OidcClient">
       <Version>3.1.2</Version>
     </PackageReference>
+    <PackageReference Include="System.Text.Encodings.Web">
+      <Version>4.5.1</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Toolkit.Wpf.UI.Controls.WebView">
       <Version>6.1.1</Version>

--- a/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
+++ b/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
@@ -28,6 +28,9 @@
     <PackageReference Include="IdentityModel.OidcClient">
       <Version>3.1.2</Version>
     </PackageReference>
+    <PackageReference Include="System.Text.Encodings.Web">
+      <Version>4.5.1</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Toolkit.Forms.UI.Controls.WebView">
       <Version>6.1.1</Version>

--- a/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
+++ b/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
@@ -65,6 +65,9 @@
     <PackageReference Include="IdentityModel.OidcClient">
       <Version>3.1.2</Version>
     </PackageReference>
+    <PackageReference Include="System.Text.Encodings.Web">
+      <Version>4.5.1</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
+++ b/test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR fixes a vulnerability that exists in System.Text.Encodings.Web:

![image](https://user-images.githubusercontent.com/2146903/116608181-3276ba00-a933-11eb-8762-8f7e6d887368.png)

Here is a github issue on the dotnet runtime repository with more context: dotnet/runtime#49377

Also fixed a few vulnerabilities that got reported in our test project.