### PR TITLE
Fix for XCode 12.5

### DIFF
--- a/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
@@ -56,7 +56,7 @@ namespace Auth0.OidcClient
             ASWebAuthenticationSession asWebAuthenticationSession = null;
             asWebAuthenticationSession = new ASWebAuthenticationSession(
                 new NSUrl(options.StartUrl),
-                options.EndUrl,
+                new NSUrl(options.EndUrl).Scheme,
                 (callbackUrl, error) =>
                 {
                     tcs.SetResult(CreateBrowserResult(callbackUrl, error));


### PR DESCRIPTION
### Changes

Since version 12.5 (released on 26 Apr 2021), Xcode no longer accepts an entire URL for the ASWebAuthenticationSession scheme value. This PR extracts the scheme from the URL and uses just that, instead of the whole URL.

### References

Fixes #189

Same fix has been applied here https://github.com/auth0/react-native-auth0/pull/369

### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
