### PR TITLE
Add Android ability to auto-close browser after returning to the app

### DIFF
--- a/src/Auth0.OidcClient.Android/AndroidBrowserBase.cs
+++ b/src/Auth0.OidcClient.Android/AndroidBrowserBase.cs
@@ -20,18 +20,32 @@ namespace Auth0.OidcClient
         /// <summary>
         /// Whether this browser should launch a new Android Task.
         /// </summary>
-        protected bool IsNewTask;
+        protected readonly bool IsNewTask;
+
+        /// <summary>
+        /// Whether this browser should close itself when returning to the Android task. Default is <b>false</b>, keeping the browser open in the background when returning to the main application.
+        /// </summary>
+        public bool AutoCloseBrowser { get; set; }
 
         /// <summary>
         /// Default constructor for <see cref="AndroidBrowserBase"/> that provides assignment
         /// of context and IsNewTask when called by subclasses.
         /// </summary>
         /// <param name="context">Optional <see cref="Context"/> to provide on subsequent callbacks.</param>
-        protected AndroidBrowserBase(Context context = null)
+        /// <param name="autoCloseBrowser">Optional parameter to provide the <see cref="Activity"/> to close the browser after use.</param>
+        protected AndroidBrowserBase(Context context = null, bool autoCloseBrowser = false)
         {
             this.context = context;
             IsNewTask = context == null;
+
+            this.AutoCloseBrowser = autoCloseBrowser;
         }
+
+        /// <summary>
+        /// Provide the optional constructor to 1) provide no context and 2) set the <param name="autoCloseBrowser"> property.</param>
+        /// </summary>
+        /// <param name="autoCloseBrowser">Whether to keep the browser window open or to close it after end use.</param>
+        protected AndroidBrowserBase(bool autoCloseBrowser) : this(null, autoCloseBrowser) { }
 
         /// <inheritdoc/>
         public Task<BrowserResult> InvokeAsync(BrowserOptions options, CancellationToken cancellationToken = default)

--- a/src/Auth0.OidcClient.Android/Auth0Client.cs
+++ b/src/Auth0.OidcClient.Android/Auth0Client.cs
@@ -26,7 +26,7 @@ namespace Auth0.OidcClient
         public Auth0Client(Auth0ClientOptions options)
             : base(options, "xamarin-android")
         {
-            options.Browser = options.Browser ?? new AutoSelectBrowser();
+            options.Browser = options.Browser ?? new AutoSelectBrowser(options.AutoCloseBrowser);
 
             var defaultRedirectUri = options.RedirectUri == null || options.PostLogoutRedirectUri == null
                 ? GetConventionCallbackUri(options.Domain) : null;
@@ -52,7 +52,7 @@ namespace Auth0.OidcClient
         public Auth0Client(Auth0ClientOptions options, Activity activity)
             : base(options, "xamarin-android")
         {
-            options.Browser = options.Browser ?? new AutoSelectBrowser(activity);
+            options.Browser = options.Browser ?? new AutoSelectBrowser(activity, options.AutoCloseBrowser);
 
             var defaultRedirectUri = options.RedirectUri == null || options.PostLogoutRedirectUri == null ?
                 GetActivityIntentCallbackUri(activity) ?? GetConventionCallbackUri(options.Domain) : null;

--- a/src/Auth0.OidcClient.Android/AutoSelectBrowser.cs
+++ b/src/Auth0.OidcClient.Android/AutoSelectBrowser.cs
@@ -12,14 +12,16 @@ namespace Auth0.OidcClient
         /// Create a new instance of <see cref="AutoSelectBrowser"/> for a given <see cref="Context"/>.
         /// </summary>
         /// <param name="context"><see cref="Context"/> provided to any subsequent callback.</param>
-        public AutoSelectBrowser(Context context) : base(context)
+        /// <param name="autoCloseBrowser">Whether to close the browser when returning to the main application or to keep it open.</param>
+        public AutoSelectBrowser(Context context, bool autoCloseBrowser = false) : base(context)
         {
+            this.AutoCloseBrowser = autoCloseBrowser;
         }
 
         /// <summary>
         /// Create a new instance of <see cref="AutoSelectBrowser"/>.
         /// </summary>
-        internal AutoSelectBrowser() : base(null)
+        internal AutoSelectBrowser(bool autoCloseBrowser = false) : this(null, autoCloseBrowser)
         {
         }
     }

--- a/src/Auth0.OidcClient.Android/ChromeCustomTabsBrowser.cs
+++ b/src/Auth0.OidcClient.Android/ChromeCustomTabsBrowser.cs
@@ -29,6 +29,13 @@ namespace Auth0.OidcClient
             {
                 if (IsNewTask)
                     customTabsIntent.Intent.AddFlags(ActivityFlags.NewTask);
+
+                if (AutoCloseBrowser)
+                {
+                    customTabsIntent.Intent.AddFlags(ActivityFlags.NoHistory);
+                    customTabsIntent.Intent.AddFlags(ActivityFlags.ClearTop);
+                }
+
                 customTabsIntent.LaunchUrl(context, uri);
             }
         }

--- a/src/Auth0.OidcClient.Core/Auth0ClientOptions.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientOptions.cs
@@ -117,6 +117,11 @@ namespace Auth0.OidcClient
         public TimeSpan? MaxAge { get; set; }
 
         /// <summary>
+        /// When returning to the main application, is the browser to be closed automatically (<b>true</b>) or kept open (<b>false</b>).
+        /// </summary>
+        public bool AutoCloseBrowser { get; set; }
+
+        /// <summary>
         /// Create a new instance of the <see cref="Auth0ClientOptions"/> class used to configure options for
         /// <see cref="Auth0ClientBase"/> implementations by way of their constructors.
         /// </summary>


### PR DESCRIPTION
On Android the login browser is kept open in the background when the authentication window return control to the main application. If the customTabsIntent is called with the flags ActivityFlags.NoHistory and ActivityFlags.ClearTop, the browser will close itself. See https://forums.xamarin.com/discussion/100286/xamarin-auth-android-chrome-custom-tabs-doesnt-close-on-redirect for further details

### Changes

Please describe both what is changing and why this is important. Include:

- Added property AutoCloseBrowser to class AndroidBrowserBase
- Added optional parameter to the AndroidBrowserBase to initialize the AutoCloseBrowser property.
- Extended Auth0ClientOptions with an 'AutoCloseBrowser' option to be used in the Auth0Client initialization/creation.

### References

Please include relevant links supporting this change such as a:
[This discussion]( https://forums.xamarin.com/discussion/100286/xamarin-auth-android-chrome-custom-tabs-doesnt-close-on-redirect)

### Testing

I implemented the library manually into my own project and added the new feature and verified the Auth0 browser window indeed was closed after I returned to the main app again.

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
