### PR TITLE
Ensure WinForms WebView works in Windows Server

### DIFF
--- a/src/Auth0.OidcClient.WinForms/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WinForms/WebViewBrowser.cs
@@ -49,7 +49,7 @@ namespace Auth0.OidcClient
             var window = _formFactory();
             var webView = new WebViewCompatible { Dock = DockStyle.Fill };
 
-            webView.NavigationStarting += (sender, e) =>
+            webView.NavigationCompleted += (sender, e) =>
             {
                 if (e.Uri.AbsoluteUri.StartsWith(options.EndUrl))
                 {


### PR DESCRIPTION
On WindowsServer WebViewCompatible didnt fire `NavigationStarting` while it does fire `NavigationCompleted`. On Windows (non server), both `NavigationStarting` and `NavigationCompleted` are fired, so we can handle `NavigationCompleted` instead of `NavigationStarting` in both Server and Non Server environments.

There isn't much information to find as to why this event doesn't fire on Windows Server, neither is this part opensource.