### PR TITLE
Update Core dependency on OidcClient

### DIFF
--- a/nuget/Auth0.OidcClient.Core.nuspec
+++ b/nuget/Auth0.OidcClient.Core.nuspec
@@ -70,7 +70,7 @@
     <tags>Auth0 OIDC</tags>
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="IdentityModel.OidcClient" version="3.1.2" />
+        <dependency id="IdentityModel.OidcClient" version="4.0.0" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="5.6.0" />
         <dependency id="System.Text.Encodings.Web" version="4.5.1" />
       </group>


### PR DESCRIPTION
The Core package is configured to still allow v3 of OidcClient, while it should be v4 minimum.