### PR TITLE
Update to WebView2

### DIFF
--- a/nuget/Auth0.OidcClient.WPF.nuspec
+++ b/nuget/Auth0.OidcClient.WPF.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.WPF</id>
-    <version>3.2.4</version>
+    <version>4.0.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for WPF apps</description>
     <releaseNotes>
+      Version 4.0.0
+      - Update to WebView2
+
       Version 3.2.4
       - Fix dependency issue with System.Text.Json
 
@@ -104,11 +107,11 @@
     <dependencies>
       <group targetFramework="net462">
         <dependency id="Auth0.OidcClient.Core" version="3.2.4" />
-        <dependency id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="6.1.1"/>
+        <dependency id="Microsoft.Web.WebView2" version="1.0.1108.44" />
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Auth0.OidcClient.Core" version="3.2.4" />
-        <dependency id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="6.1.1"/>
+        <dependency id="Microsoft.Web.WebView2" version="1.0.1108.44" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.WinForms.nuspec
+++ b/nuget/Auth0.OidcClient.WinForms.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.WinForms</id>
-    <version>3.2.5</version>
+    <version>4.0.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for WinForms apps</description>
     <releaseNotes>
+      Version 4.0.0
+      - Update to WebView2
+
       Version 3.2.5
       - Fix dependency issue with System.Text.Json
 
@@ -97,11 +100,11 @@
     <dependencies>
       <group targetFramework="net462">
         <dependency id="Auth0.OidcClient.Core" version="3.2.4" />
-        <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="6.1.1"/>
+        <dependency id="Microsoft.Web.WebView2" version="1.0.1108.44" />
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Auth0.OidcClient.Core" version="3.2.4" />
-        <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="6.1.1"/>
+        <dependency id="Microsoft.Web.WebView2" version="1.0.1108.44" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
+++ b/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
@@ -29,8 +29,6 @@
       <Version>4.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Toolkit.Wpf.UI.Controls.WebView">
-      <Version>6.1.2</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1108.44" />
   </ItemGroup>
 </Project>

--- a/src/Auth0.OidcClient.WPF/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.WPF/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Windows;
 
 [assembly: AssemblyTitle("Auth0.OidcClient.WPF")]
 [assembly: AssemblyProduct("Auth0.OidcClient")]
-[assembly: AssemblyVersion("3.2.3")]
-[assembly: AssemblyFileVersion("3.2.3")]
+[assembly: AssemblyVersion("4.0.0")]
+[assembly: AssemblyFileVersion("4.0.0")]
 [assembly: ComVisible(false)]
 
 [assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]

--- a/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
@@ -1,5 +1,5 @@
 ﻿using IdentityModel.OidcClient.Browser;
-using Microsoft.Toolkit.Wpf.UI.Controls;
+using Microsoft.Web.WebView2.Wpf;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,7 +8,7 @@ using System.Windows;
 namespace Auth0.OidcClient
 {
     /// <summary>
-    /// Implements the <see cref="IBrowser"/> interface using the <see cref="WebViewCompatible"/> control.
+    /// Implements the <see cref="IBrowser"/> interface using the <see cref="WebView2"/> control.
     /// </summary>
     public class WebViewBrowser : IBrowser
     {
@@ -49,12 +49,12 @@ namespace Auth0.OidcClient
             var tcs = new TaskCompletionSource<BrowserResult>();
 
             var window = _windowFactory();
-            var webView = new WebViewCompatible();
+            var webView = new WebView2();
             window.Content = webView;
 
             webView.NavigationStarting += (sender, e) =>
             {
-                if (e.Uri.AbsoluteUri.StartsWith(options.EndUrl))
+                if (e.Uri.StartsWith(options.EndUrl))
                 {
                     tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.Success, Response = e.Uri.ToString() });
                     if (_shouldCloseWindow)
@@ -72,7 +72,9 @@ namespace Auth0.OidcClient
             };
 
             window.Show();
-            webView.Navigate(options.StartUrl);
+
+            webView.CoreWebView2InitializationCompleted += (sender, e) => webView.CoreWebView2.Navigate(options.StartUrl);
+            webView.EnsureCoreWebView2Async();
 
             return tcs.Task;
         }

--- a/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
+++ b/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
@@ -29,8 +29,6 @@
       <Version>4.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="Microsoft.Toolkit.Forms.UI.Controls.WebView">
-      <Version>6.1.2</Version>
-    </PackageReference>
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1108.44" />
   </ItemGroup>
 </Project>

--- a/src/Auth0.OidcClient.WinForms/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.WinForms/Properties/AssemblyInfo.cs
@@ -3,6 +3,6 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Auth0.OidcClient.WinForms")]
 [assembly: AssemblyProduct("Auth0.OidcClient")]
-[assembly: AssemblyVersion("3.2.4")]
-[assembly: AssemblyFileVersion("3.2.4")]
+[assembly: AssemblyVersion("4.0.0")]
+[assembly: AssemblyFileVersion("4.0.0")]
 [assembly: ComVisible(false)]

--- a/src/Auth0.OidcClient.WinForms/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WinForms/WebViewBrowser.cs
@@ -1,5 +1,5 @@
 ﻿using IdentityModel.OidcClient.Browser;
-using Microsoft.Toolkit.Forms.UI.Controls;
+using Microsoft.Web.WebView2.WinForms;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -8,7 +8,7 @@ using System.Windows.Forms;
 namespace Auth0.OidcClient
 {
     /// <summary>
-    /// Implements the <see cref="IBrowser"/> interface using the <see cref="WebViewCompatible"/> control.
+    /// Implements the <see cref="IBrowser"/> interface using the <see cref="WebView2"/> control.
     /// </summary>
     public class WebViewBrowser : IBrowser
     {
@@ -16,9 +16,9 @@ namespace Auth0.OidcClient
 
         /// <summary>
         /// Creates a new instance of <see cref="WebViewBrowser"/> with a specified function to create the <see cref="Form"/>
-        /// used to host the <see cref="WebViewCompatible"/> control.
+        /// used to host the <see cref="WebView2"/> control.
         /// </summary>
-        /// <param name="formFactory">The function used to create the <see cref="Form"/> that will host the <see cref="WebViewCompatible"/> control.</param>
+        /// <param name="formFactory">The function used to create the <see cref="Form"/> that will host the <see cref="WebView2"/> control.</param>
         public WebViewBrowser(Func<Form> formFactory)
         {
             _formFactory = formFactory;
@@ -47,11 +47,11 @@ namespace Auth0.OidcClient
             var tcs = new TaskCompletionSource<BrowserResult>();
 
             var window = _formFactory();
-            var webView = new WebViewCompatible { Dock = DockStyle.Fill };
+            var webView = new WebView2 { Dock = DockStyle.Fill };
 
-            webView.NavigationCompleted += (sender, e) =>
+            webView.NavigationStarting += (sender, e) =>
             {
-                if (e.Uri.AbsoluteUri.StartsWith(options.EndUrl))
+                if (e.Uri.StartsWith(options.EndUrl))
                 {
                     tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.Success, Response = e.Uri.ToString() });
                     window.Close();
@@ -67,7 +67,9 @@ namespace Auth0.OidcClient
 
             window.Controls.Add(webView);
             window.Show();
-            webView.Navigate(options.StartUrl);
+
+            webView.CoreWebView2InitializationCompleted += (sender, e) => webView.CoreWebView2.Navigate(options.StartUrl);
+            webView.EnsureCoreWebView2Async();
 
             return tcs.Task;
         }


### PR DESCRIPTION
### Changes

We cannot use Auth0 WPF library in dotnet 6 project because of a deprecated dependency. We need to remove package Microsoft.Toolkit.Wpf.UI.Controls.WebView and replace it by Microsoft.Web.WebView2.

Main classes remain unchanged. 

Bump to version 4.0 because changing the main dependency.

### References

Deprecated notice
https://docs.microsoft.com/en-us/dotnet/api/microsoft.toolkit.wpf.ui.controls.webview?view=win-comm-toolkit-dotnet-6.1

### Testing

Run the WPF and WinForms applications in "Interactive Test Apps" folder. 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
