### PR TITLE
Update vmImage to use windows-2019

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'windows-latest'
+  vmImage: 'windows-2019'
 
 variables:
   solution: '**/*.sln'


### PR DESCRIPTION
Recently, `windows-latest` got updated from `windows-2019` to `windows-2022`, this is breaking our build.

Even though we might want to look into moving to `2022`, for now, let's fix our CI by pinning it to `2019`.