### PR TITLE
Do not mutate dictionary when passed to our SDK

### DIFF
--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -173,7 +173,7 @@ namespace Auth0.OidcClient
         {
             var dictionary = ObjectToDictionary(values);
 
-            if (_options.EnableTelemetry)
+            if (_options.EnableTelemetry && !dictionary.ContainsKey("auth0Client"))
                 dictionary.Add("auth0Client", _userAgent);
 
             return dictionary;
@@ -189,7 +189,7 @@ namespace Auth0.OidcClient
         private Dictionary<string, string> ObjectToDictionary(object values)
         {
             if (values is Dictionary<string, string> dictionary)
-                return dictionary;
+                return dictionary.ToDictionary(entry => entry.Key, entry => entry.Value);
 
             dictionary = new Dictionary<string, string>();
             if (values != null)


### PR DESCRIPTION
### Changes

Ensures we do not mutate the dictionairy when passed to our SDK using Login, Logout or RefreshToken.
Also adds an extra guard to not add `auth0Client` when it already exists, which was the root of discovering the mutation we are doing here.

### References

Closes #229

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
