### PR TITLE
[SDK-3651] Expose OidcClient LoggerFactory

### DIFF
--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -149,7 +149,7 @@ namespace Auth0.OidcClient
                 RedirectUri = options.RedirectUri ?? $"https://{_options.Domain}/mobile",
                 PostLogoutRedirectUri = options.PostLogoutRedirectUri ?? $"https://{_options.Domain}/mobile",
                 ClockSkew = options.Leeway,
-                LoggerFactory = options.LoggerFactory
+                LoggerFactory = options.LoggerFactory,
 
                 Policy = {
                     RequireAccessTokenHash = false

--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -149,6 +149,7 @@ namespace Auth0.OidcClient
                 RedirectUri = options.RedirectUri ?? $"https://{_options.Domain}/mobile",
                 PostLogoutRedirectUri = options.PostLogoutRedirectUri ?? $"https://{_options.Domain}/mobile",
                 ClockSkew = options.Leeway,
+                LoggerFactory = options.LoggerFactory
 
                 Policy = {
                     RequireAccessTokenHash = false

--- a/src/Auth0.OidcClient.Core/Auth0ClientOptions.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientOptions.cs
@@ -1,4 +1,5 @@
 ﻿using IdentityModel.OidcClient.Browser;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Net.Http;
 
@@ -115,6 +116,11 @@ namespace Auth0.OidcClient
         /// Optional limit on the how long since the user was last authenticated.
         /// </summary>
         public TimeSpan? MaxAge { get; set; }
+
+        /// <summary>
+        /// Optional ILoggerFactory implementation to use for logging purposes.
+        /// </summary>
+        public ILoggerFactory LoggerFactory { get; set; } = new LoggerFactory();
 
         /// <summary>
         /// Create a new instance of the <see cref="Auth0ClientOptions"/> class used to configure options for


### PR DESCRIPTION
### Changes

Creates a `LoggerFactory` with a default value set to `new LoggerFactory()`, but enabling the developer to provide their own.

This LoggerFactory is then passed to `OidcClientOptions` when constructing the underlying `OidcClient`, allowing the developers to be notified on any logs happening inside the `OidcClient` package.

### References

Closes #223 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
