### PR TITLE
Ensure backchannel is used with the IdTokenValidator

### DIFF
--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -22,6 +22,7 @@ namespace Auth0.OidcClient
     public abstract class Auth0ClientBase : IAuth0Client
     {
         private readonly IdTokenRequirements _idTokenRequirements;
+        private readonly IdTokenValidator _idTokenValidator;
         private readonly Auth0ClientOptions _options;
         private readonly string _userAgent;
         private IdentityModel.OidcClient.OidcClient _oidcClient;
@@ -43,6 +44,7 @@ namespace Auth0.OidcClient
             _options = options;
             _idTokenRequirements = new IdTokenRequirements($"https://{_options.Domain}/", _options.ClientId, options.Leeway, options.MaxAge);
             _userAgent = CreateAgentString(platformName);
+            _idTokenValidator = new IdTokenValidator(options.BackchannelHandler);
         }
 
         /// <inheritdoc />
@@ -65,7 +67,7 @@ namespace Auth0.OidcClient
                     _idTokenRequirements.Organization = finalExtraParameters["organization"];
                 }
 
-                await IdTokenValidator.AssertTokenMeetsRequirements(_idTokenRequirements, result.IdentityToken); // Nonce is created & tested by OidcClient
+                await _idTokenValidator.AssertTokenMeetsRequirements(_idTokenRequirements, result.IdentityToken); // Nonce is created & tested by OidcClient
             }
 
             return result;
@@ -121,7 +123,7 @@ namespace Auth0.OidcClient
                     _idTokenRequirements.Organization = finalExtraParameters["Organization"];
                 }
 
-                await IdTokenValidator.AssertTokenMeetsRequirements(_idTokenRequirements, result.IdentityToken); // Nonce is created & tested by OidcClient
+                await _idTokenValidator.AssertTokenMeetsRequirements(_idTokenRequirements, result.IdentityToken); // Nonce is created & tested by OidcClient
             }
 
             return result;

--- a/src/Auth0.OidcClient.Core/Tokens/AsymmetricSignatureVerifier.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/AsymmetricSignatureVerifier.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Auth0.OidcClient.Tokens
@@ -9,11 +10,17 @@ namespace Auth0.OidcClient.Tokens
     internal class AsymmetricSignatureVerifier : ISignatureVerifier
     {
         private readonly IList<JsonWebKey> keys;
+        private readonly JsonWebKeys jsonWebKeys;
 
-        public static async Task<AsymmetricSignatureVerifier> ForJwks(string issuer)
+        public AsymmetricSignatureVerifier(HttpMessageHandler backchannel = null)
         {
-            var jsonWebKeys = await JsonWebKeys.GetForIssuer(issuer);
-            return new AsymmetricSignatureVerifier(jsonWebKeys.Keys);
+            jsonWebKeys = new JsonWebKeys(backchannel);
+        }
+
+        public async Task<AsymmetricSignatureVerifier> ForJwks(string issuer)
+        {
+            var jsonWebKeysSet = await jsonWebKeys.GetForIssuer(issuer);
+            return new AsymmetricSignatureVerifier(jsonWebKeysSet.Keys);
         }
 
         public AsymmetricSignatureVerifier(IList<JsonWebKey> keys)

--- a/test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
+++ b/test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
@@ -14,8 +14,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Auth0.OidcClient.Core\Auth0.OidcClient.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Remove="Moq" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Changes

This PR ensures we use the Backchannel for retrieving the Oidc Configuration, which is useful in situations where proxies are used or any reason where you are unable to use the default HttpMessageHandler. An example would be for Android and programmatically setting the AndroidClientHandler as per https://community.auth0.com/t/introduction-of-additional-certificate-authorities-xamarin-on-android-failure-guidance/97583

Even though this is changing static classes to regular classes, it's only touching internal classes so shouldn't realy introduce a breaking change for anyone.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
