### PR TITLE
Add .NET version field to bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug Report.yml
@@ -59,6 +59,13 @@ body:
     validations:
       required: true
 
+  - type: input
+    id: environment-dotnet-version
+    attributes:
+      label: .NET version
+    validations:
+      required: true
+
   - type: dropdown
     id: environment-platform
     attributes:


### PR DESCRIPTION
### Changes

This PR adds a field to the [bug report](https://github.com/auth0/auth0-oidc-client-net/blob/master/.github/ISSUE_TEMPLATE/Bug%20Report.yml) issue form for the .NET version. 

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
