### PR TITLE
Support scope with RefreshTokens

### DIFF
--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -111,10 +111,22 @@ namespace Auth0.OidcClient
         }
 
         /// <inheritdoc/>
-        public async Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, object extraParameters = null, CancellationToken cancellationToken = default)
+        public Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default)
+        {
+            return this.RefreshTokenAsync(refreshToken, null, null, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, object extraParameters, CancellationToken cancellationToken = default)
+        {
+            return this.RefreshTokenAsync(refreshToken, null, extraParameters, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public async Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, string scope, object extraParameters = null, CancellationToken cancellationToken = default)
         {
             var finalExtraParameters = AppendTelemetry(extraParameters);
-            var result = await OidcClient.RefreshTokenAsync(refreshToken, new Parameters(finalExtraParameters), cancellationToken: cancellationToken);
+            var result = await OidcClient.RefreshTokenAsync(refreshToken, new Parameters(finalExtraParameters), scope, cancellationToken: cancellationToken);
 
             if (!result.IsError)
             {

--- a/src/Auth0.OidcClient.Core/IAuth0Client.cs
+++ b/src/Auth0.OidcClient.Core/IAuth0Client.cs
@@ -57,10 +57,30 @@ namespace Auth0.OidcClient
         /// </summary>
         /// <param name="refreshToken">Refresh token which was issued during the authorization flow, or subsequent
         /// calls to <see cref="IdentityModel.OidcClient.OidcClient.RefreshTokenAsync"/>.</param>
+        /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> that can be used to cancel the request.</param>
+        /// <returns>A <see cref="RefreshTokenResult"/> with the refreshed tokens.</returns>
+        Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Generates a new set of tokens based on a refresh token. 
+        /// </summary>
+        /// <param name="refreshToken">Refresh token which was issued during the authorization flow, or subsequent
+        /// calls to <see cref="IdentityModel.OidcClient.OidcClient.RefreshTokenAsync"/>.</param>
         /// <param name="extraParameters">Optional extra parameters that need to be passed to the endpoint.</param>
         /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> that can be used to cancel the request.</param>
         /// <returns>A <see cref="RefreshTokenResult"/> with the refreshed tokens.</returns>
         Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, object extraParameters = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Generates a new set of tokens based on a refresh token. 
+        /// </summary>
+        /// <param name="refreshToken">Refresh token which was issued during the authorization flow, or subsequent
+        /// calls to <see cref="IdentityModel.OidcClient.OidcClient.RefreshTokenAsync"/>.</param>
+        /// <param name="scope">Space separated list of the requested scopes.</param>
+        /// <param name="extraParameters">Optional extra parameters that need to be passed to the endpoint.</param>
+        /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> that can be used to cancel the request.</param>
+        /// <returns>A <see cref="RefreshTokenResult"/> with the refreshed tokens.</returns>
+        Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, string scope, object extraParameters = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets the user claims from the userinfo endpoint.


### PR DESCRIPTION
### Changes

Supports the scope parameter when using Refresh Tokens to enable Access Token Descoping.

### References

Closes #241 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
