### PR TITLE
Support Organization Name

### DIFF
--- a/src/Auth0.OidcClient.Core/Tokens/Auth0ClaimNames.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/Auth0ClaimNames.cs
@@ -4,8 +4,9 @@
         /// List of Auth0 specific claims
         /// </summary>
         internal static class Auth0ClaimNames
-        {
-            internal static string Organization = "org_id";
-        }
+    {
+        internal static string OrganizationId = "org_id";
+        internal static string OrganizationName = "org_name";
+    }
     
 }

--- a/src/Auth0.OidcClient.Core/Tokens/IdTokenRequirements.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/IdTokenRequirements.cs
@@ -39,7 +39,7 @@ namespace Auth0.OidcClient.Tokens
         /// </summary>
         /// <remarks>
         /// - If you provide an Organization ID (a string with the prefix `org_`), it will be validated against the `org_id` claim of your user's ID Token. The validation is case-sensitive.
-        /// - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token.The validation is case-insensitive.
+        /// - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token. The validation is case-insensitive.
         /// </remarks>
         public string Organization;
 

--- a/src/Auth0.OidcClient.Core/Tokens/IdTokenRequirements.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/IdTokenRequirements.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Security.Claims;
 
 namespace Auth0.OidcClient.Tokens
 {
@@ -36,6 +37,10 @@ namespace Auth0.OidcClient.Tokens
         /// <summary>
         /// Required organization the token must be for.
         /// </summary>
+        /// <remarks>
+        /// - If you provide an Organization ID (a string with the prefix `org_`), it will be validated against the `org_id` claim of your user's ID Token. The validation is case-sensitive.
+        /// - If you provide an Organization Name (a string *without* the prefix `org_`), it will be validated against the `org_name` claim of your user's ID Token.The validation is case-insensitive.
+        /// </remarks>
         public string Organization;
 
         /// <summary>

--- a/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
@@ -149,9 +149,9 @@ namespace Auth0.OidcClient.Tokens
                 var expectedOrganization = organizationClaim == Auth0ClaimNames.OrganizationName ? required.Organization.ToLower() : required.Organization;
 
                 if (string.IsNullOrWhiteSpace(organizationClaimValue))
-                    throw new IdTokenValidationException($"Organization claim ({organizationClaim}) must be a string present in the ID token.");
+                    throw new IdTokenValidationException($"Organization ({organizationClaim}) claim must be a string present in the ID token.");
                 if (organizationClaimValue != expectedOrganization)
-                    throw new IdTokenValidationException($"Organization claim ({organizationClaim}) mismatch in the ID token; expected \"{expectedOrganization}\", found \"{organizationClaimValue}\".");
+                    throw new IdTokenValidationException($"Organization ({organizationClaim}) claim mismatch in the ID token; expected \"{expectedOrganization}\", found \"{organizationClaimValue}\".");
             }
         }
 

--- a/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
@@ -143,11 +143,15 @@ namespace Auth0.OidcClient.Tokens
             // Organization
             if (!string.IsNullOrWhiteSpace(required.Organization))
             {
-                var organization = GetClaimValue(token.Claims, Auth0ClaimNames.Organization);
-                if (string.IsNullOrWhiteSpace(organization))
-                    throw new IdTokenValidationException("Organization claim must be a string present in the ID token.");
-                if (organization != required.Organization)
-                    throw new IdTokenValidationException($"Organization claim mismatch in the ID token; expected \"{required.Organization}\", found \"{organization}\".");
+                var organizationClaim = required.Organization.StartsWith("org_") ? Auth0ClaimNames.OrganizationId : Auth0ClaimNames.OrganizationName;
+                var rawOrganizationClaimValue = GetClaimValue(token.Claims, organizationClaim);
+                var organizationClaimValue = organizationClaim == Auth0ClaimNames.OrganizationName ? rawOrganizationClaimValue?.ToLower() : rawOrganizationClaimValue;
+                var expectedOrganization = organizationClaim == Auth0ClaimNames.OrganizationName ? required.Organization.ToLower() : required.Organization;
+
+                if (string.IsNullOrWhiteSpace(organizationClaimValue))
+                    throw new IdTokenValidationException($"Organization claim ({organizationClaim}) must be a string present in the ID token.");
+                if (organizationClaimValue != expectedOrganization)
+                    throw new IdTokenValidationException($"Organization claim ({organizationClaim}) mismatch in the ID token; expected \"{expectedOrganization}\", found \"{organizationClaimValue}\".");
             }
         }
 

--- a/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
+++ b/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
@@ -17,53 +17,6 @@ using Xunit;
 
 namespace Auth0.OidcClient.Core.UnitTests.Tokens
 {
-    internal class JwtTokenFactory
-    {
-        private readonly SecurityKey securityKey;
-        private readonly string algorithm;
-
-        public JwtTokenFactory(SecurityKey securityKey, string algorithm)
-        {
-            this.securityKey = securityKey;
-            this.algorithm = algorithm;
-        }
-
-        public string GenerateToken(string issuer, string audience, string sub, IList<Claim> additionalClaims = null)
-        {
-            var signingCredentials = new SigningCredentials(securityKey, algorithm);
-
-            var tokenHandler = new JwtSecurityTokenHandler();
-            var tokenDescriptor = CreateSecurityTokenDescriptor(issuer, audience, sub, signingCredentials, additionalClaims);
-
-            var token = tokenHandler.CreateToken(tokenDescriptor);
-
-            return tokenHandler.WriteToken(token);
-        }
-
-        private static SecurityTokenDescriptor CreateSecurityTokenDescriptor(string issuer, string audience, string sub, SigningCredentials signingCredentials, IList<Claim> additionalClaims = null)
-        {
-            var claims = new List<Claim> {
-                new Claim(JwtRegisteredClaimNames.Sub, sub),
-                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
-                new Claim(JwtRegisteredClaimNames.AuthTime, DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds.ToString()),
-            };
-
-            if (additionalClaims != null)
-            {
-                claims.AddRange(additionalClaims);
-            }
-
-            return new SecurityTokenDescriptor
-            {
-                Subject = new ClaimsIdentity(claims),
-                IssuedAt = DateTime.UtcNow,
-                Expires = DateTime.UtcNow.AddSeconds(180),
-                Issuer = issuer,
-                Audience = audience,
-                SigningCredentials = signingCredentials
-            };
-        }
-    }
 
     public class IdTokenValidatorUnitTests
     {

--- a/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
+++ b/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
@@ -271,7 +271,7 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
                 MaxAge = TimeSpan.FromSeconds(100),
                 Organization = "org_123"
             }));
-            Assert.Equal("Organization claim (org_id) must be a string present in the ID token.", ex.Message);
+            Assert.Equal("Organization (org_id) claim must be a string present in the ID token.", ex.Message);
         }
 
         [Fact]
@@ -305,7 +305,7 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
                 Organization = "org_456"
             }));
 
-            Assert.Equal($"Organization claim (org_id) mismatch in the ID token; expected \"org_456\", found \"org_123\".", ex.Message);
+            Assert.Equal($"Organization (org_id) claim mismatch in the ID token; expected \"org_456\", found \"org_123\".", ex.Message);
         }
 
         [Fact]
@@ -322,7 +322,7 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
                 MaxAge = TimeSpan.FromSeconds(100),
                 Organization = "123"
             }));
-            Assert.Equal("Organization claim (org_name) must be a string present in the ID token.", ex.Message);
+            Assert.Equal("Organization (org_name) claim must be a string present in the ID token.", ex.Message);
         }
 
         [Fact]
@@ -356,7 +356,7 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
                 Organization = "organizationb"
             }));
 
-            Assert.Equal($"Organization claim (org_name) mismatch in the ID token; expected \"organizationb\", found \"organizationa\".", ex.Message);
+            Assert.Equal($"Organization (org_name) claim mismatch in the ID token; expected \"organizationb\", found \"organizationa\".", ex.Message);
         }
 
 

--- a/test/Auth0.OidcClient.Core.UnitTests/Tokens/JwtTokenFactory.cs
+++ b/test/Auth0.OidcClient.Core.UnitTests/Tokens/JwtTokenFactory.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.IdentityModel.Tokens;
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+
+namespace Auth0.OidcClient.Core.UnitTests.Tokens
+{
+    internal class JwtTokenFactory
+    {
+        private readonly SecurityKey securityKey;
+        private readonly string algorithm;
+
+        public JwtTokenFactory(SecurityKey securityKey, string algorithm)
+        {
+            this.securityKey = securityKey;
+            this.algorithm = algorithm;
+        }
+
+        public string GenerateToken(string issuer, string audience, string sub, IList<Claim> additionalClaims = null)
+        {
+            var signingCredentials = new SigningCredentials(securityKey, algorithm);
+
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var tokenDescriptor = CreateSecurityTokenDescriptor(issuer, audience, sub, signingCredentials, additionalClaims);
+
+            var token = tokenHandler.CreateToken(tokenDescriptor);
+
+            return tokenHandler.WriteToken(token);
+        }
+
+        private static SecurityTokenDescriptor CreateSecurityTokenDescriptor(string issuer, string audience, string sub, SigningCredentials signingCredentials, IList<Claim> additionalClaims = null)
+        {
+            var claims = new List<Claim> {
+                new Claim(JwtRegisteredClaimNames.Sub, sub),
+                new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+                new Claim(JwtRegisteredClaimNames.AuthTime, DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds.ToString()),
+            };
+
+            if (additionalClaims != null)
+            {
+                claims.AddRange(additionalClaims);
+            }
+
+            return new SecurityTokenDescriptor
+            {
+                Subject = new ClaimsIdentity(claims),
+                IssuedAt = DateTime.UtcNow,
+                Expires = DateTime.UtcNow.AddSeconds(180),
+                Issuer = issuer,
+                Audience = audience,
+                SigningCredentials = signingCredentials
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Changes

Adds support for the organization name by extending the ID Token validation as follows:

If organization is set and has the org_ prefix, we expect an org_id claim
If organization is set and does not have the org_ prefix, we expect an org_name claim

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
