### PR TITLE
Correctly set IdentityModel.OidcClient dependency to v5

### DIFF
--- a/nuget/Auth0.OidcClient.Core.nuspec
+++ b/nuget/Auth0.OidcClient.Core.nuspec
@@ -89,7 +89,7 @@
     <tags>Auth0 OIDC</tags>
     <dependencies>
       <group targetFramework="netstandard2.0">
-        <dependency id="IdentityModel.OidcClient" version="4.0.0" />
+        <dependency id="IdentityModel.OidcClient" version="5.2.1" />
         <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.12.2" />
         <dependency id="System.Text.Encodings.Web" version="5.0.1" />
         <dependency id="System.Text.Json" version="5.0.1" />


### PR DESCRIPTION
### Changes

IdentityModel.OidcClient was not correctly set to v5 in the nuspec file.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
