### PR TITLE
Release .NET6 support for WPF and Winforms

### DIFF
--- a/nuget/Auth0.OidcClient.WPF.nuspec
+++ b/nuget/Auth0.OidcClient.WPF.nuspec
@@ -13,7 +13,7 @@
     <description>Auth0 OIDC Client for WPF apps</description>
     <releaseNotes>
     Version 3.5.0
-      - Add support for .NET6+ through supporting WebView2
+      - Add support for .NET6+ by supporting WebView2
 
     Version 3.4.1
       - Do not lowercase org_name claim

--- a/nuget/Auth0.OidcClient.WPF.nuspec
+++ b/nuget/Auth0.OidcClient.WPF.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.WPF</id>
-    <version>3.4.1</version>
+    <version>3.5.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for WPF apps</description>
     <releaseNotes>
+    Version 3.5.0
+      - Add support for .NET6+ through supporting WebView2
+
     Version 3.4.1
       - Do not lowercase org_name claim
 

--- a/nuget/Auth0.OidcClient.WinForms.nuspec
+++ b/nuget/Auth0.OidcClient.WinForms.nuspec
@@ -13,7 +13,7 @@
     <description>Auth0 OIDC Client for WinForms apps</description>
     <releaseNotes>
     Version 3.5.0
-      - Add support for .NET6+ through supporting WebView2
+      - Add support for .NET6+ by supporting WebView2
 
     Version 3.4.1
       - Do not lowercase org_name claim

--- a/nuget/Auth0.OidcClient.WinForms.nuspec
+++ b/nuget/Auth0.OidcClient.WinForms.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.WinForms</id>
-    <version>3.4.1</version>
+    <version>3.5.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for WinForms apps</description>
     <releaseNotes>
+    Version 3.5.0
+      - Add support for .NET6+ through supporting WebView2
+
     Version 3.4.1
       - Do not lowercase org_name claim
   


### PR DESCRIPTION
**Added**

- Added .NET6.0+ support to `Auth0.OidcClient.Winforms` [#267](https://github.com/auth0/auth0-oidc-client-net/pull/267) ([frederikprijck](https://github.com/frederikprijck))
- Added .NET6.0+ support to `Auth0.OidcClient.Wpf` [#266](https://github.com/auth0/auth0-oidc-client-net/pull/267) ([joseangelmt](https://github.com/joseangelmt))