### PR TITLE
Remove Token Endpoint Auth Method from configuration steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Create a **Native Application** in the [Auth0 Dashboard](https://manage.auth0.co
 > **If you're using an existing application**, verify that you have configured the following settings in your Native Application:
 >
 > - Click on the "Settings" tab of your application's page.
-> - Ensure that "Token Endpoint Authentication Method" under "Application Properties" is set to "None"
 > - Scroll down and click on the "Show Advanced Settings" link.
 > - Under "Advanced Settings", click on the "OAuth" tab.
 > - Ensure that "JsonWebToken Signature Algorithm" is set to `RS256` and that "OIDC Conformant" is enabled.


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

Due to a recent refactor in the management UI this is no longer shown by default on new Native applications. It will be shown on older Native applications but the setting is locked to None

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
