### PR TITLE
Migrate iOS SDK to SDK style project

### DIFF
--- a/nuget/Auth0.OidcClient.iOS.nuspec
+++ b/nuget/Auth0.OidcClient.iOS.nuspec
@@ -112,8 +112,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="../src/Auth0.OidcClient.iOS/bin/Release/Auth0.OidcClient.dll" target="lib\Xamarin.iOS10" />
-    <file src="../src/Auth0.OidcClient.iOS/bin/Release/Auth0.OidcClient.xml" target="lib\Xamarin.iOS10" />
+    <file src="../src/Auth0.OidcClient.iOS/bin/Release/xamarin.ios10/Auth0.OidcClient.dll" target="lib\Xamarin.iOS10" />
+    <file src="../src/Auth0.OidcClient.iOS/bin/Release/xamarin.ios10/Auth0.OidcClient.xml" target="lib\Xamarin.iOS10" />
     <file src="..\build\Auth0Icon.png" />
   </files>
 </package>

--- a/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
+++ b/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
@@ -1,49 +1,26 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{D6CD228A-D8FA-4250-B770-CCC9CCD5698B}</ProjectGuid>
-    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <OutputType>Library</OutputType>
+    <TargetFramework>Xamarin.iOS10</TargetFramework>
     <RootNamespace>Auth0.OidcClient</RootNamespace>
-    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Auth0.OidcClient</AssemblyName>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <Product>Auth0.OidcClient</Product>
+    <AssemblyVersion>3.5.1</AssemblyVersion>
+    <AssemblyFileVersion>3.5.1</AssemblyFileVersion>
+    <Version>3.5.1</Version>
+    <NeutralLanguage>en</NeutralLanguage>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <DefineConstants>$(DefineConstants);</DefineConstants>    
+    <LangVersion>default</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
+    <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release</OutputPath>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <ConsolePause>false</ConsolePause>
-    <DocumentationFile>bin\Release\Auth0.OidcClient.xml</DocumentationFile>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>..\..\build\Auth0OidcClientStrongName.snk</AssemblyOriginatorKeyFile>
+  <PropertyGroup Condition=" '$(Configuration)'=='Release' ">
+    <DebugType>pdbonly</DebugType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Core" />
-    <Reference Include="Xamarin.iOS" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Resources\" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="ActivityMediator.cs" />
     <Compile Include="AutoSelectBrowser.cs" />
@@ -53,7 +30,6 @@
     <Compile Include="ASWebAuthenticationSessionOptions.cs" />
     <Compile Include="SFAuthenticationSessionBrowser.cs" />
     <Compile Include="SFSafariViewControllerBrowser.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Auth0.OidcClient.Core\Auth0.OidcClient.Core.csproj">
@@ -66,5 +42,4 @@
       <Version>5.2.1</Version>
     </PackageReference>
   </ItemGroup>
-  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/src/Auth0.OidcClient.iOS/Properties/AssemblyInfo.cs
+++ b/src/Auth0.OidcClient.iOS/Properties/AssemblyInfo.cs
@@ -1,8 +1,0 @@
-﻿using System.Reflection;
-using System.Runtime.InteropServices;
-
-[assembly: AssemblyTitle("Auth0.OidcClient.iOS")]
-[assembly: AssemblyProduct("Auth0.OidcClient")]
-[assembly: AssemblyVersion("3.3.3")]
-[assembly: AssemblyFileVersion("3.3.3")]
-[assembly: ComVisible(false)]


### PR DESCRIPTION
### Changes

Migrates the iOS SDK to be an SDK style project to allow for targetting multiple platforms (Xamarin and .NET iOS).

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
