### PR TITLE
Add .NET6 target for iOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,13 @@ steps:
   displayName: 'Install .NET SDK'
   inputs:
     version: 6.x
-    performMultiLevelLookup: true
+
+- task: DotNetCoreCLI@2
+  displayName: "Install .NET iOS workload"
+  inputs:
+    command: 'custom'
+    custom: 'workload'
+    arguments: 'install ios'
 
 - task: NuGetToolInstaller@1
 

--- a/nuget/Auth0.OidcClient.iOS.nuspec
+++ b/nuget/Auth0.OidcClient.iOS.nuspec
@@ -114,6 +114,8 @@
   <files>
     <file src="../src/Auth0.OidcClient.iOS/bin/Release/xamarin.ios10/Auth0.OidcClient.dll" target="lib\Xamarin.iOS10" />
     <file src="../src/Auth0.OidcClient.iOS/bin/Release/xamarin.ios10/Auth0.OidcClient.xml" target="lib\Xamarin.iOS10" />
+    <file src="../src/Auth0.OidcClient.iOS/bin/Release/net6.0-ios/Auth0.OidcClient.dll" target="lib\net6.0-ios13.0" />
+    <file src="../src/Auth0.OidcClient.iOS/bin/Release/net6.0-ios/Auth0.OidcClient.xml" target="lib\net6.0-ios13.0" />
     <file src="..\build\Auth0Icon.png" />
   </files>
 </package>

--- a/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
+++ b/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
+<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha4">
   <PropertyGroup>
-    <TargetFrameworks>Xamarin.iOS10</TargetFrameworks>
+    <TargetFrameworks>xamarin.ios10;net6.0-ios</TargetFrameworks>
     <RootNamespace>Auth0.OidcClient</RootNamespace>
     <AssemblyName>Auth0.OidcClient</AssemblyName>
     <AssemblyTitle>Auth0.OidcClient.iOS</AssemblyTitle>


### PR DESCRIPTION
### Changes

Add support to run our iOS SDK on both Xamarin and .NET iOS applications. To compile for both platforms, we need to use [Xamarin.Legacy.Sdk ](https://github.com/xamarin/Xamarin.Legacy.Sdk).

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
