### PR TITLE
Add .NET6 target for Android

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,13 @@ steps:
   displayName: 'Install .NET SDK'
   inputs:
     version: 6.x
-    performMultiLevelLookup: true
+
+- task: DotNetCoreCLI@2
+  displayName: "Install .NET Android workload"
+  inputs:
+    command: 'custom'
+    custom: 'workload'
+    arguments: 'install android'
 
 - task: NuGetToolInstaller@1
 

--- a/nuget/Auth0.OidcClient.AndroidX.nuspec
+++ b/nuget/Auth0.OidcClient.AndroidX.nuspec
@@ -66,6 +66,8 @@
   <files>
     <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\monoandroid10.0\Auth0.OidcClient.dll" target="lib\MonoAndroid10" />
     <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\monoandroid10.0\Auth0.OidcClient.xml" target="lib\MonoAndroid10" />
+    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\net6.0-android\Auth0.OidcClient.dll" target="lib\net6.0-android26.0" />
+    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\net6.0-android\Auth0.OidcClient.xml" target="lib\net6.0-android26.0" />
     <file src="..\build\Auth0Icon.png" />
   </files>
 </package>

--- a/nuget/Auth0.OidcClient.AndroidX.nuspec
+++ b/nuget/Auth0.OidcClient.AndroidX.nuspec
@@ -66,8 +66,8 @@
   <files>
     <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\monoandroid10.0\Auth0.OidcClient.dll" target="lib\MonoAndroid10" />
     <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\monoandroid10.0\Auth0.OidcClient.xml" target="lib\MonoAndroid10" />
-    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\net6.0-android\Auth0.OidcClient.dll" target="lib\net6.0-android26.0" />
-    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\net6.0-android\Auth0.OidcClient.xml" target="lib\net6.0-android26.0" />
+    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\net6.0-android\Auth0.OidcClient.dll" target="lib\net6.0-android29.0" />
+    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\net6.0-android\Auth0.OidcClient.xml" target="lib\net6.0-android29.0" />
     <file src="..\build\Auth0Icon.png" />
   </files>
 </package>

--- a/src/Auth0.OidcClient.AndroidX/Auth0.OidcClient.AndroidX.csproj
+++ b/src/Auth0.OidcClient.AndroidX/Auth0.OidcClient.AndroidX.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
+﻿<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha4">
   <PropertyGroup>
-    <TargetFramework>MonoAndroid10.0</TargetFramework>
+    <TargetFrameworks>MonoAndroid10.0;net6.0-android</TargetFrameworks>
     <RootNamespace>Auth0.OidcClient</RootNamespace>
     <AssemblyName>Auth0.OidcClient</AssemblyName>
     <Product>Auth0.OidcClient</Product>


### PR DESCRIPTION
### Changes

Add support to run our Android SDK on both Xamarin and .NET Android applications. To compile for both platforms, we need to use [Xamarin.Legacy.Sdk ](https://github.com/xamarin/Xamarin.Legacy.Sdk).

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors. 

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
