### PR TITLE
Set TargetFrameworkVersion to v11 for Android

### DIFF
--- a/nuget/Auth0.OidcClient.Android.nuspec
+++ b/nuget/Auth0.OidcClient.Android.nuspec
@@ -125,14 +125,14 @@
     <copyright>Copyright 2017-2020 Auth0, Inc.</copyright>
     <tags>Auth0 OIDC Android Xamarin</tags>
     <dependencies>
-      <group targetFramework="MonoAndroid10">
+      <group targetFramework="MonoAndroid11">
         <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="..\src\Auth0.OidcClient.Android\bin\Release\monoandroid10.0\Auth0.OidcClient.dll" target="lib\MonoAndroid10" />
-    <file src="..\src\Auth0.OidcClient.Android\bin\Release\monoandroid10.0\Auth0.OidcClient.xml" target="lib\MonoAndroid10" />
+    <file src="..\src\Auth0.OidcClient.Android\bin\Release\monoandroid11.0\Auth0.OidcClient.dll" target="lib\MonoAndroid11" />
+    <file src="..\src\Auth0.OidcClient.Android\bin\Release\monoandroid11.0\Auth0.OidcClient.xml" target="lib\MonoAndroid11" />
     <file src="..\build\Auth0Icon.png" />
   </files>
 </package>

--- a/nuget/Auth0.OidcClient.AndroidX.nuspec
+++ b/nuget/Auth0.OidcClient.AndroidX.nuspec
@@ -58,14 +58,14 @@
     <copyright>Copyright 2017-2020 Auth0, Inc.</copyright>
     <tags>Auth0 OIDC Android Xamarin</tags>
     <dependencies>
-      <group targetFramework="MonoAndroid10">
+      <group targetFramework="MonoAndroid11">
         <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
       </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\monoandroid10.0\Auth0.OidcClient.dll" target="lib\MonoAndroid10" />
-    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\monoandroid10.0\Auth0.OidcClient.xml" target="lib\MonoAndroid10" />
+    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\monoandroid11.0\Auth0.OidcClient.dll" target="lib\MonoAndroid11" />
+    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\monoandroid11.0\Auth0.OidcClient.xml" target="lib\MonoAndroid11" />
     <file src="..\build\Auth0Icon.png" />
   </files>
 </package>

--- a/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
+++ b/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
@@ -12,6 +12,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <DefineConstants>$(DefineConstants);</DefineConstants>    
     <LangVersion>default</LangVersion>
+    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
   </PropertyGroup>
    <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugType>full</DebugType>

--- a/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
+++ b/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid10.0</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid11.0</TargetFrameworks>
     <RootNamespace>Auth0.OidcClient</RootNamespace>
     <AssemblyName>Auth0.OidcClient</AssemblyName>
     <Product>Auth0.OidcClient</Product>

--- a/src/Auth0.OidcClient.AndroidX/Auth0.OidcClient.AndroidX.csproj
+++ b/src/Auth0.OidcClient.AndroidX/Auth0.OidcClient.AndroidX.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
   <PropertyGroup>
-    <TargetFramework>MonoAndroid10.0</TargetFramework>
+    <TargetFramework>MonoAndroid11.0</TargetFramework>
     <RootNamespace>Auth0.OidcClient</RootNamespace>
     <AssemblyName>Auth0.OidcClient</AssemblyName>
     <Product>Auth0.OidcClient</Product>

--- a/test/Android/Android.csproj
+++ b/test/Android/Android.csproj
@@ -15,7 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>


### PR DESCRIPTION
### Changes

Updating android to target Android 11 as per https://developer.android.com/google/play/requirements/target-sdk

**Note**: Even thought this could be seen as a breaking change, it actualy isn't as anything lower isn't suppported anymore by Android so we will include this in a non-major bump.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
