### PR TITLE
Release support for .NET6 for iOS and AndroidX

### DIFF
--- a/nuget/Auth0.OidcClient.Android.nuspec
+++ b/nuget/Auth0.OidcClient.Android.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.Android</id>
-    <version>3.4.1</version>
+    <version>3.5.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Xamarin Android apps</description>
     <releaseNotes>
+    Version 3.5.0
+      - Set Android Target Framework Version to v11
+    
     Version 3.4.1
       - Do not lowercase org_name claim
 

--- a/nuget/Auth0.OidcClient.AndroidX.nuspec
+++ b/nuget/Auth0.OidcClient.AndroidX.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.AndroidX</id>
-    <version>3.4.1</version>
+    <version>3.5.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Xamarin AndroidX apps</description>
     <releaseNotes>
+    Version 3.5.0
+      - Set Android Target Framework Version to v11
+      - Support .NET6 and above
+
     Version 3.4.1
       - Do not lowercase org_name claim
 

--- a/nuget/Auth0.OidcClient.iOS.nuspec
+++ b/nuget/Auth0.OidcClient.iOS.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.iOS</id>
-    <version>3.5.1</version>
+    <version>3.6.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Xamarin iOS apps</description>
     <releaseNotes>
+    Version 3.6.0
+      - Support .NET6 and above
+
     Version 3.5.1
       - Do not lowercase org_name claim
 

--- a/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
+++ b/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
@@ -5,9 +5,9 @@
     <AssemblyName>Auth0.OidcClient</AssemblyName>
     <Product>Auth0.OidcClient</Product>
     <AssemblyTitle>Auth0.OidcClient.Android</AssemblyTitle>
-    <AssemblyVersion>3.4.1</AssemblyVersion>
-    <AssemblyFileVersion>3.4.1</AssemblyFileVersion>
-    <Version>3.4.1</Version>
+    <AssemblyVersion>3.5.0</AssemblyVersion>
+    <AssemblyFileVersion>3.5.0</AssemblyFileVersion>
+    <Version>3.5.0</Version>
     <NeutralLanguage>en</NeutralLanguage>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <DefineConstants>$(DefineConstants);</DefineConstants>    

--- a/src/Auth0.OidcClient.AndroidX/Auth0.OidcClient.AndroidX.csproj
+++ b/src/Auth0.OidcClient.AndroidX/Auth0.OidcClient.AndroidX.csproj
@@ -5,9 +5,9 @@
     <AssemblyName>Auth0.OidcClient</AssemblyName>
     <Product>Auth0.OidcClient</Product>
     <AssemblyTitle>Auth0.OidcClient.AndroidX</AssemblyTitle>
-    <AssemblyVersion>3.4.1</AssemblyVersion>
-    <AssemblyFileVersion>3.4.1</AssemblyFileVersion>
-    <Version>3.4.1</Version>
+    <AssemblyVersion>3.5.0</AssemblyVersion>
+    <AssemblyFileVersion>3.5.0</AssemblyFileVersion>
+    <Version>3.5.0</Version>
     <NeutralLanguage>en</NeutralLanguage>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <DefineConstants>$(DefineConstants);</DefineConstants>    

--- a/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
+++ b/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
@@ -1,13 +1,13 @@
-<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha4">
+﻿<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha4">
   <PropertyGroup>
     <TargetFrameworks>xamarin.ios10;net6.0-ios</TargetFrameworks>
     <RootNamespace>Auth0.OidcClient</RootNamespace>
     <AssemblyName>Auth0.OidcClient</AssemblyName>
     <AssemblyTitle>Auth0.OidcClient.iOS</AssemblyTitle>
     <Product>Auth0.OidcClient</Product>
-    <AssemblyVersion>3.5.1</AssemblyVersion>
-    <AssemblyFileVersion>3.5.1</AssemblyFileVersion>
-    <Version>3.5.1</Version>
+    <AssemblyVersion>3.6.0</AssemblyVersion>
+    <AssemblyFileVersion>3.6.0</AssemblyFileVersion>
+    <Version>3.6.0</Version>
     <NeutralLanguage>en</NeutralLanguage>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <DefineConstants>$(DefineConstants);</DefineConstants>    


### PR DESCRIPTION
**Added**

- Added .NET6.0+ support to Auth0.OidcClient.iOS [#274](https://github.com/auth0/auth0-oidc-client-net/pull/274) ([frederikprijck](https://github.com/frederikprijck))
- Added .NET6.0+ support to Auth0.OidcClient.AndroidX [#276](https://github.com/auth0/auth0-oidc-client-net/pull/276) ([frederikprijck](https://github.com/frederikprijck))

Going forward, use `Auth0.OidcClient.AndroidX` instead of `Auth0.OidcClient.Android`, as `Auth0.OidcClient.Android` will never be able to run on .NET6 and above.

**Modified**

- Set TargetFrameworkVersion to v11 for Android and AndroidX [#278](https://github.com/auth0/auth0-oidc-client-net/pull/278) ([frederikprijck](https://github.com/frederikprijck))

**Note:** Even thought this could be seen as a breaking change, it actualy isn't as anything lower isn't suppported anymore by Android so we will include this in a non-major bump.