### PR TITLE
Encourage using AndroidX instead of Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Install-Package Auth0.OidcClient.UWP
 Install-Package Auth0.OidcClient.WPF
 Install-Package Auth0.OidcClient.WinForms
 Install-Package Auth0.OidcClient.iOS
-Install-Package Auth0.OidcClient.Android
 Install-Package Auth0.OidcClient.AndroidX
 ```
+
+> *Note*: As `Auth0.OidcClient.Android` relies on support packages which have been deprecated nby Google since 2019, there is no way for `Auth0.OidcClient.Android` to ever work on .NET 6 and above. If you wish to integrate Auth0 in an Android application running on .NET6 or above, use `Auth0.OidcClient.AndroidX` instead.
 
 ### Configure Auth0
 

--- a/nuget/Auth0.OidcClient.Android.nuspec
+++ b/nuget/Auth0.OidcClient.Android.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/auth0/auth0-oidc-client-net</projectUrl>
     <icon>Auth0Icon.png</icon>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <description>Auth0 OIDC Client for Xamarin Android apps</description>
+    <description>Auth0 OIDC Client for Xamarin Android apps. Relies on deprecated support libraries from Google, use Auth0.OidcClient.AndroidX instead.</description>
     <releaseNotes>
     Version 3.4.1
       - Do not lowercase org_name claim


### PR DESCRIPTION
### Changes

We offter two SDKs for Android:

- Auth0.OidcClient.Android
- Auth0.OidcClient.AndroidX

The defference relies in the [support libraries](https://developer.android.com/topic/libraries/support-library) used, where Auth0.OidcClient.Android uses deprecated support libraries which wont ever work on .NET6.

Therefore, going forward, our recommendation is to use `Auth0.OidcClient.AndroidX`, which work with both Xamarin and .NET Android.

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
- [ ] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
