### PR TITLE
Add support for Windows using WinUIEx

### DIFF
--- a/src/Auth0.OidcClient.MAUI/Auth0.OidcClient.MAUI.csproj
+++ b/src/Auth0.OidcClient.MAUI/Auth0.OidcClient.MAUI.csproj
@@ -2,6 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFrameworks>net6.0;net6.0-android;net6.0-ios;net6.0-maccatalyst</TargetFrameworks>
+		<TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net6.0-windows10.0.19041.0</TargetFrameworks>
 		<UseMaui>true</UseMaui>
 		<SingleProject>true</SingleProject>
 		<ImplicitUsings>enable</ImplicitUsings>
@@ -9,6 +10,9 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">14.2</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">14.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
+
+		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
+		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 
@@ -30,6 +34,12 @@
 	<ItemGroup>
 	  <PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />
 	</ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0-windows10.0.19041.0'">
+	  <PackageReference Include="WinUIEx">
+	    <Version>2.2.0</Version>
+	  </PackageReference>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.3.230502000" />
+	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\Auth0.OidcClient.Core\Auth0.OidcClient.Core.csproj" />
 	</ItemGroup>
@@ -39,8 +49,8 @@
 	  <None Remove="Platforms\Android\" />
 	</ItemGroup>
 	<ItemGroup>
-    <None Include="README.md" Pack="true" PackagePath="\" />
-</ItemGroup>
+		<None Include="README.md" Pack="true" PackagePath="\" />
+	</ItemGroup>
 	<ItemGroup>
 	  <BundleResource Include="..\..\build\Auth0Icon.png" Pack="true" PackagePath="">
 	    <Link>Auth0Icon.png</Link>

--- a/src/Auth0.OidcClient.MAUI/WebAuthenticatorBrowser.cs
+++ b/src/Auth0.OidcClient.MAUI/WebAuthenticatorBrowser.cs
@@ -13,9 +13,11 @@ public class WebAuthenticatorBrowser : IBrowser
     {
         try
         {
-            WebAuthenticatorResult result = await WebAuthenticator.Default.AuthenticateAsync(
-                new Uri(options.StartUrl),
-                new Uri(options.EndUrl));
+#if WINDOWS
+            var result = await WinUIEx.WebAuthenticator.AuthenticateAsync(new Uri(options.StartUrl), new Uri(options.EndUrl));
+#else
+            var result = await WebAuthenticator.Default.AuthenticateAsync(new Uri(options.StartUrl), new Uri(options.EndUrl));
+#endif
 
             var url = new RequestUrl(options.EndUrl)
                 .Create(new Parameters(result.Properties));


### PR DESCRIPTION
### Changes

With MAUI not having built-in support for opening a browser on windows yet, we want to integrate support for Windows using WinUIEx, a community package to solve the lack of support for Windows.

See: 

- [[Bug] Maui Essentials WebAuthenticator not working in WinUI · Issue #2702 · dotnet/maui](https://github.com/dotnet/maui/issues/2702)
- [WebAuthenticationBroker API that supports all WinAppSDK OS's and application types · Issue #441 · microsoft/WindowsAppSDK](https://github.com/microsoft/WindowsAppSDK/issues/441)

Relevant links for WinUIEx:

- https://dotmorten.github.io/WinUIEx/concepts/WebAuthenticator.html
- https://dotmorten.github.io/WinUIEx/concepts/Maui.html

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
