### PR TITLE
Drop MAUI suffix in the namespace to align with other packages

### DIFF
--- a/src/Auth0.OidcClient.MAUI/Auth0Client.cs
+++ b/src/Auth0.OidcClient.MAUI/Auth0Client.cs
@@ -1,4 +1,4 @@
-﻿namespace Auth0.OidcClient.MAUI;
+﻿namespace Auth0.OidcClient;
 
 /// <summary>
 /// Primary class for performing authentication and authorization operations with Auth0 using the

--- a/src/Auth0.OidcClient.MAUI/WebAuthenticatorBrowser.cs
+++ b/src/Auth0.OidcClient.MAUI/WebAuthenticatorBrowser.cs
@@ -1,4 +1,4 @@
-﻿namespace Auth0.OidcClient.MAUI;
+﻿namespace Auth0.OidcClient;
 
 using IdentityModel.OidcClient.Browser;
 using IdentityModel.Client;


### PR DESCRIPTION
### Changes

Drop MAUI suffix in the namespace to align with other packages

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
