### PR TITLE
Fix CI by skipping sign check on workload install

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ steps:
   inputs:
     command: 'custom'
     custom: 'workload'
-    arguments: 'install ios'
+    arguments: 'install ios --skip-sign-check'
 
 - task: DotNetCoreCLI@2
   displayName: "Install .NET Android workload"


### PR DESCRIPTION
### Changes

CI is currently having issues with package signature validation when installing the workloads. This PR temporarily disables that as per https://github.com/dotnet/maui/issues/9573

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
- [ ] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
