### PR TITLE
Bump test dependencies to fix vulnerability

### DIFF
--- a/test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
+++ b/test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
@@ -6,7 +6,7 @@
     <AssemblyOriginatorKeyFile>..\..\build\Auth0OidcClientStrongName.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
### Changes

Bumps Microsoft.NET.Test.Sdk

### References

```
✗ Insecure Defaults [High Severity][https://security.snyk.io/vuln/SNYK-DOTNET-NEWTONSOFTJSON-2774678] in Newtonsoft.Json@9.0.1
    introduced by Microsoft.NET.Test.Sdk@16.11.0 > Microsoft.TestPlatform.TestHost@16.11.0 > Newtonsoft.Json@9.0.1
  This issue was fixed in versions: 13.0.1
  ✗ Regular Expression Denial of Service (ReDoS) [High Severity][https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMTEXTREGULAREXPRESSIONS-[174](https://github.com/auth0/auth0-oidc-client-net/actions/runs/6798140636/job/18482169715#step:10:175)708] in System.Text.RegularExpressions@4.3.0
    introduced by Microsoft.NET.Test.Sdk@16.11.0 > Microsoft.TestPlatform.TestHost@16.11.0 > Newtonsoft.Json@9.0.1 > System.Text.RegularExpressions@4.3.0 and 14 other path(s)
  This issue was fixed in versions: 4.3.1
```

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [ ] All existing and new tests complete without errors
- [ ] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
