### PR TITLE
Remove AssemblyOriginatorKeyFile from MAUI project

### DIFF
--- a/src/Auth0.OidcClient.MAUI.Platforms.Windows/Auth0.OidcClient.MAUI.Platforms.Windows.csproj
+++ b/src/Auth0.OidcClient.MAUI.Platforms.Windows/Auth0.OidcClient.MAUI.Platforms.Windows.csproj
@@ -10,7 +10,6 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-    	<AssemblyOriginatorKeyFile>..\..\build\Auth0OidcClientStrongName.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
### Changes

We do not need to strong-name our files file for MAUI, so removing that reference to the SNK file.

### References

- https://github.com/dotnet/runtime/blob/main/docs/project/strong-name-signing.md
- https://learn.microsoft.com/en-us/dotnet/standard/assembly/strong-named

> For .NET Core and .NET 5+, strong-named assemblies do not provide material benefits. The runtime never validates the strong-name signature, nor does it use the strong-name for assembly binding.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
