### PR TITLE
Pin workload version for .NET6 by using global.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '11'
 
       - name: Install .NET
         uses: actions/setup-dotnet@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,6 @@ jobs:
 
       - name: Install .NET
         uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 6.x
 
       - name: Install .NET Android and iOS workload
         run: dotnet workload install android ios

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Install .NET
         uses: actions/setup-dotnet@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           dotnet-version: 6.x
 
       - name: Install .NET Android and iOS workload
-        run: dotnet workload install android ios
+        run: dotnet workload install android ios --sdk-version=6.0.416 --from-rollback-file https://maui.blob.core.windows.net/metadata/rollbacks/6.0.553.json
 
       - name: Setup NuGet
         uses: nuget/setup-nuget@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           dotnet-version: 6.x
 
       - name: Install .NET Android and iOS workload
-        run: dotnet workload install android ios --sdk-version=6.0.416 --from-rollback-file https://maui.blob.core.windows.net/metadata/rollbacks/6.0.553.json
+        run: dotnet workload install android ios
 
       - name: Setup NuGet
         uses: nuget/setup-nuget@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Install .NET
         uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: 6.x
 
       - name: Install .NET Android and iOS workload
         run: dotnet workload install android ios

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           dotnet-version: 6.x
 
       - name: Install .NET Android and iOS workload
-        run: dotnet workload install android ios
+        run: dotnet workload install android ios --sdk-version=6.0.416 --from-rollback-file https://maui.blob.core.windows.net/metadata/rollbacks/6.0.553.json
 
       - name: Setup NuGet
         uses: nuget/setup-nuget@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,12 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.inputs.branch }}
 
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+
       - name: Install .NET
         uses: actions/setup-dotnet@v3
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
           dotnet-version: 6.x
 
       - name: Install .NET Android and iOS workload
-        run: dotnet workload install android ios --sdk-version=6.0.416 --from-rollback-file https://maui.blob.core.windows.net/metadata/rollbacks/6.0.553.json
+        run: dotnet workload install android ios
 
       - name: Setup NuGet
         uses: nuget/setup-nuget@v1

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+      "version": "6.0.417",
+      "rollForward": "latestFeature"
+    }
+  }


### PR DESCRIPTION
### Changes

With .NET8 being released, it automatically installs workloads for .NET8, while we are still on 6.
Future plans are to move to .NET8, but for now lets pin the workloads instead.

As the workloads are installed based on the global.json file, we are adding the global.json file in this PR. Without this file, it would install the latest workloads (which are for .NET8, not .NET6).

As `actions/setup-dotnet` also reads the global.json file, we are also removing the specific version from the workflow files.

Because of changes to the hosted CI runners for .NET, we also need to install Java manually in order to build Android, see https://github.com/dotnet/maui/issues/18906. Because Xamarin needs Java 11, we are installing Java 11.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
