### PR TITLE
Remove support for Client Secret

### DIFF
--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -170,11 +170,6 @@ namespace Auth0.OidcClient
                 }
             };
 
-#pragma warning disable CS0618 // ClientSecret will be removed in a future update.
-            if (!String.IsNullOrWhiteSpace(oidcClientOptions.ClientSecret))
-                oidcClientOptions.ClientSecret = options.ClientSecret;
-#pragma warning restore CS0618
-
             if (options.RefreshTokenMessageHandler != null)
                 oidcClientOptions.RefreshTokenInnerHttpHandler = options.RefreshTokenMessageHandler;
 

--- a/src/Auth0.OidcClient.Core/Auth0ClientOptions.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientOptions.cs
@@ -22,13 +22,6 @@ namespace Auth0.OidcClient
         public string ClientId { get; set; }
 
         /// <summary>
-        /// Your Auth0 Client Secret.
-        /// </summary>
-        [Obsolete("Client Secrets should not be used in non-confidential clients such as native desktop and mobile apps. " +
-            "This property will be removed in a future release.")]
-        public string ClientSecret { get; set; }
-
-        /// <summary>
         /// Your Auth0 tenant domain.
         /// </summary>
         /// <remarks>

--- a/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
@@ -38,10 +38,13 @@ namespace Auth0.OidcClient.Tokens
         {
             if (string.IsNullOrWhiteSpace(rawIDToken))
                 throw new IdTokenValidationException("ID token is required but missing.");
-
-            var token = DecodeToken(rawIDToken); 
             
-            (signatureVerifier ?? await assymetricSignatureVerifier.ForJwks(required.Issuer)).VerifySignature(rawIDToken);
+            var token = DecodeToken(rawIDToken);
+
+            // Signature Verification is optional because the token endpoint is over HTTPS.
+            // As we allow HS256 signed Id token, but we do not have a Client Secret we skip signature verification for HS256.
+            if (token.SignatureAlgorithm != "HS256")
+                (signatureVerifier ?? await assymetricSignatureVerifier.ForJwks(required.Issuer)).VerifySignature(rawIDToken);
 
             AssertTokenClaimsMeetRequirements(required, token, pointInTime ?? DateTime.Now);
         }

--- a/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
@@ -40,11 +40,9 @@ namespace Auth0.OidcClient.Tokens
                 throw new IdTokenValidationException("ID token is required but missing.");
 
             var token = DecodeToken(rawIDToken);
-
-            // For now we want to support HS256 + ClientSecret as we just had a major release.
-            // TODO: In the next major (v4.0) we should remove this condition as well as Auth0ClientOptions.ClientSecret
-            if (token.SignatureAlgorithm != "HS256")
-                (signatureVerifier ?? await assymetricSignatureVerifier.ForJwks(required.Issuer)).VerifySignature(rawIDToken);
+            
+            if (signatureVerifier != null)
+                (await assymetricSignatureVerifier.ForJwks(required.Issuer)).VerifySignature(rawIDToken);
 
             AssertTokenClaimsMeetRequirements(required, token, pointInTime ?? DateTime.Now);
         }

--- a/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
@@ -38,7 +38,7 @@ namespace Auth0.OidcClient.Tokens
         {
             if (string.IsNullOrWhiteSpace(rawIDToken))
                 throw new IdTokenValidationException("ID token is required but missing.");
-            
+
             var token = DecodeToken(rawIDToken);
 
             // Signature Verification is optional because the token endpoint is over HTTPS.

--- a/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
+++ b/src/Auth0.OidcClient.Core/Tokens/IdTokenValidator.cs
@@ -39,10 +39,9 @@ namespace Auth0.OidcClient.Tokens
             if (string.IsNullOrWhiteSpace(rawIDToken))
                 throw new IdTokenValidationException("ID token is required but missing.");
 
-            var token = DecodeToken(rawIDToken);
+            var token = DecodeToken(rawIDToken); 
             
-            if (signatureVerifier != null)
-                (await assymetricSignatureVerifier.ForJwks(required.Issuer)).VerifySignature(rawIDToken);
+            (signatureVerifier ?? await assymetricSignatureVerifier.ForJwks(required.Issuer)).VerifySignature(rawIDToken);
 
             AssertTokenClaimsMeetRequirements(required, token, pointInTime ?? DateTime.Now);
         }

--- a/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
+++ b/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
@@ -72,14 +72,6 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
         }
 
         [Fact]
-        public async void DoesNotValidateSignatureWhenSignedWithHS256()
-        {
-            var token = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTY4MTgwODk0LjIyNCwiaWF0IjoxNTY4MDA4MDk0LjIyNCwibm9uY2UiOiJhMWIyYzNkNGU1IiwiYXpwIjoidG9rZW5zLXRlc3QtMTIzIiwiYXV0aF90aW1lIjoxNTY4MDk0NDk0LjIyNH0.D5ZbbKddQMnJMLkuV76ALdvuvAShPxLVuKNvjBPn618";
-
-            await ValidateToken(token);
-        }
-
-        [Fact]
         public async void SucceedsWhenSignatureIsValid()
         {
             var token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik1qQXlNamczTWpFMVF6WXhNamhGUkVKR09FRkVSRGMzTlRoRU9EWTNRak13UVRSR056UkdRUSJ9.eyJuaWNrbmFtZSI6ImRhbWllbmcrdGVzdDQyIiwibmFtZSI6ImRhbWllbmcrdGVzdDQyQGdtYWlsLmNvbSIsInBpY3R1cmUiOiJodHRwczovL3MuZ3JhdmF0YXIuY29tL2F2YXRhci81MzFiMDJkYTllOWVjNzg3ZDBlMWE1NzA1YzQ0YzU2Nj9zPTQ4MCZyPXBnJmQ9aHR0cHMlM0ElMkYlMkZjZG4uYXV0aDAuY29tJTJGYXZhdGFycyUyRmRhLnBuZyIsInVwZGF0ZWRfYXQiOiIyMDE5LTExLTAxVDE3OjQ0OjE2LjY5NVoiLCJlbWFpbCI6ImRhbWllbmcrdGVzdDQyQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiaXNzIjoiaHR0cHM6Ly9hdXRoMC1kb3RuZXQtaW50ZWdyYXRpb24tdGVzdHMuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDVkYTY0NTNjMTIyZmI2MGE5MjRlOTI2MSIsImF1ZCI6InFtc3M5QTY2c3RQV1RPWGpSNlgxT2VBMERMYWRvTlAyIiwiaWF0IjoxNTcyNjMwMjU2LCJleHAiOjE1NzI2NjYyNTYsIm5vbmNlIjoiU09ySE9hdTlxMGl0eDRpVEZfaVgydyJ9.NomT02whkH42ISpcd_JvG4ZvQQhzPKfoWCwcgrhyLeWmnmHTo704WtsnfCqR72uw26D-ZGA5n2Yu4Jdcv2A8_leGEQm3p45-ramIDwWUu2J30m_op_5I4wFvgpbRrWSrD1_3qK1GrDnrdv8psGL8VgCf3pLLDbqbkzDmtE6OtEfDp2hEFwXs9YntREXu5Z-ufFFLz9VU5uyRg7JA95YGQNIRhzMFoUNKZAO19nrBq3HKc_iR_W9g9Y3iLPLgVVazq6zHjn3cXNKpr7JN6MUKqIB-YYJ1KDEvmaMO60xs2DAhhnkUN1OhXBLTgQ9xbCJeaxE7N48YMxPAu3HHT-rhZg";
@@ -365,8 +357,11 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
         [Fact]
         public async void DoesNotThrowWhenOrgIdAvailableButNotARequirement()
         {
-            var token = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJleHAiOjE1NjgxODA4OTQuMjI0LCJpYXQiOjE1NjgwMDgwOTQuMjI0LCJub25jZSI6ImExYjJjM2Q0ZTUiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1NjgwOTQ0OTQuMjI0LCJvcmdfaWQiOiIxMjMifQ.AsGzG0MWXzd4v-XmIN_7Elgd527jOARv7ChDECH9qUw";
+            var key = new RsaSecurityKey(new RSACryptoServiceProvider(2048));
+            var tokenFactory = new JwtTokenFactory(key, SecurityAlgorithms.RsaSha256);
 
+            var token = tokenFactory.GenerateToken("https://tokens-test.auth0.com/", "tokens-test-123", "test_sub", new List<Claim> { new Claim(JwtRegisteredClaimNames.Nonce, "a1b2c3d4e5"), new Claim("org_id", "org_123") });
+            
             await ValidateToken(token);
         }
 

--- a/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
+++ b/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
@@ -78,7 +78,7 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
 
             await ValidateToken(token);
         }
-        
+
         [Fact]
         public async void SucceedsWhenSignatureIsValid()
         {
@@ -366,7 +366,7 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
         public async void DoesNotThrowWhenOrgIdAvailableButNotARequirement()
         {
             var token = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJleHAiOjE1NjgxODA4OTQuMjI0LCJpYXQiOjE1NjgwMDgwOTQuMjI0LCJub25jZSI6ImExYjJjM2Q0ZTUiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1NjgwOTQ0OTQuMjI0LCJvcmdfaWQiOiIxMjMifQ.AsGzG0MWXzd4v-XmIN_7Elgd527jOARv7ChDECH9qUw";
-            
+
             await ValidateToken(token);
         }
 

--- a/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
+++ b/test/Auth0.OidcClient.Core.UnitTests/Tokens/IdTokenValidatorTests.cs
@@ -72,6 +72,14 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
         }
 
         [Fact]
+        public async void DoesNotValidateSignatureWhenSignedWithHS256()
+        {
+            var token = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC05OTkiXSwiZXhwIjoxNTY4MTgwODk0LjIyNCwiaWF0IjoxNTY4MDA4MDk0LjIyNCwibm9uY2UiOiJhMWIyYzNkNGU1IiwiYXpwIjoidG9rZW5zLXRlc3QtMTIzIiwiYXV0aF90aW1lIjoxNTY4MDk0NDk0LjIyNH0.D5ZbbKddQMnJMLkuV76ALdvuvAShPxLVuKNvjBPn618";
+
+            await ValidateToken(token);
+        }
+        
+        [Fact]
         public async void SucceedsWhenSignatureIsValid()
         {
             var token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6Ik1qQXlNamczTWpFMVF6WXhNamhGUkVKR09FRkVSRGMzTlRoRU9EWTNRak13UVRSR056UkdRUSJ9.eyJuaWNrbmFtZSI6ImRhbWllbmcrdGVzdDQyIiwibmFtZSI6ImRhbWllbmcrdGVzdDQyQGdtYWlsLmNvbSIsInBpY3R1cmUiOiJodHRwczovL3MuZ3JhdmF0YXIuY29tL2F2YXRhci81MzFiMDJkYTllOWVjNzg3ZDBlMWE1NzA1YzQ0YzU2Nj9zPTQ4MCZyPXBnJmQ9aHR0cHMlM0ElMkYlMkZjZG4uYXV0aDAuY29tJTJGYXZhdGFycyUyRmRhLnBuZyIsInVwZGF0ZWRfYXQiOiIyMDE5LTExLTAxVDE3OjQ0OjE2LjY5NVoiLCJlbWFpbCI6ImRhbWllbmcrdGVzdDQyQGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiaXNzIjoiaHR0cHM6Ly9hdXRoMC1kb3RuZXQtaW50ZWdyYXRpb24tdGVzdHMuYXV0aDAuY29tLyIsInN1YiI6ImF1dGgwfDVkYTY0NTNjMTIyZmI2MGE5MjRlOTI2MSIsImF1ZCI6InFtc3M5QTY2c3RQV1RPWGpSNlgxT2VBMERMYWRvTlAyIiwiaWF0IjoxNTcyNjMwMjU2LCJleHAiOjE1NzI2NjYyNTYsIm5vbmNlIjoiU09ySE9hdTlxMGl0eDRpVEZfaVgydyJ9.NomT02whkH42ISpcd_JvG4ZvQQhzPKfoWCwcgrhyLeWmnmHTo704WtsnfCqR72uw26D-ZGA5n2Yu4Jdcv2A8_leGEQm3p45-ramIDwWUu2J30m_op_5I4wFvgpbRrWSrD1_3qK1GrDnrdv8psGL8VgCf3pLLDbqbkzDmtE6OtEfDp2hEFwXs9YntREXu5Z-ufFFLz9VU5uyRg7JA95YGQNIRhzMFoUNKZAO19nrBq3HKc_iR_W9g9Y3iLPLgVVazq6zHjn3cXNKpr7JN6MUKqIB-YYJ1KDEvmaMO60xs2DAhhnkUN1OhXBLTgQ9xbCJeaxE7N48YMxPAu3HHT-rhZg";
@@ -357,10 +365,7 @@ namespace Auth0.OidcClient.Core.UnitTests.Tokens
         [Fact]
         public async void DoesNotThrowWhenOrgIdAvailableButNotARequirement()
         {
-            var key = new RsaSecurityKey(new RSACryptoServiceProvider(2048));
-            var tokenFactory = new JwtTokenFactory(key, SecurityAlgorithms.RsaSha256);
-
-            var token = tokenFactory.GenerateToken("https://tokens-test.auth0.com/", "tokens-test-123", "test_sub", new List<Claim> { new Claim(JwtRegisteredClaimNames.Nonce, "a1b2c3d4e5"), new Claim("org_id", "org_123") });
+            var token = "eyJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJhdWQiOiJ0b2tlbnMtdGVzdC0xMjMiLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJleHAiOjE1NjgxODA4OTQuMjI0LCJpYXQiOjE1NjgwMDgwOTQuMjI0LCJub25jZSI6ImExYjJjM2Q0ZTUiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1NjgwOTQ0OTQuMjI0LCJvcmdfaWQiOiIxMjMifQ.AsGzG0MWXzd4v-XmIN_7Elgd527jOARv7ChDECH9qUw";
             
             await ValidateToken(token);
         }


### PR DESCRIPTION
### Changes

With ClientSecret being marked as obsolete for 4 years now, we are removing this.

### References

- https://github.com/auth0/auth0-oidc-client-net/pull/112

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
