### PR TITLE
Drop support for WebView for WPF and Winforms and default to WebView2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
 
   push:
-    branches: ["master"]
+    branches: ["master", "feat/drop-webview"]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
 
   push:
-    branches: ["master", "feat/drop-webview"]
+    branches: ["master"]
 
 jobs:
   build:

--- a/nuget/Auth0.OidcClient.WPF.nuspec
+++ b/nuget/Auth0.OidcClient.WPF.nuspec
@@ -127,11 +127,11 @@
     <dependencies>
       <group targetFramework="net462">
         <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
-        <dependency id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="6.1.1"/>
+        <dependency id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
-        <dependency id="Microsoft.Toolkit.Wpf.UI.Controls.WebView" version="6.1.1"/>
+        <dependency id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
       </group>
       <group targetFramework="net6.0-windows7.0">
         <dependency id="Auth0.OidcClient.Core" version="3.4.1" />

--- a/nuget/Auth0.OidcClient.WinForms.nuspec
+++ b/nuget/Auth0.OidcClient.WinForms.nuspec
@@ -120,11 +120,11 @@
     <dependencies>
       <group targetFramework="net462">
         <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
-        <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="6.1.1"/>
+        <dependency id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
       </group>
       <group targetFramework="netcoreapp3.1">
         <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
-        <dependency id="Microsoft.Toolkit.Forms.UI.Controls.WebView" version="6.1.1"/>
+        <dependency id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
       </group>
       <group targetFramework="net6.0-windows7.0">
         <dependency id="Auth0.OidcClient.Core" version="3.4.1" />

--- a/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
+++ b/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
@@ -31,9 +31,7 @@
 		<When Condition="'$(TargetFramework)'!='net6.0-windows'">
 			<ItemGroup>
 				<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-				<PackageReference Include="Microsoft.Toolkit.Wpf.UI.Controls.WebView">
-					<Version>6.1.2</Version>
-				</PackageReference>
+				<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
 			</ItemGroup>
 		</When>
 		<When Condition="'$(TargetFramework)'=='net6.0-windows'">

--- a/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
@@ -1,9 +1,5 @@
 ﻿using IdentityModel.OidcClient.Browser;
-#if NET6_0
-using WebViewCompatible = Microsoft.Web.WebView2.Wpf.WebView2;
-#else
-using Microsoft.Toolkit.Wpf.UI.Controls;
-#endif
+using Microsoft.Web.WebView2.Wpf;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -54,16 +50,12 @@ namespace Auth0.OidcClient
 
             var window = _windowFactory();
             #pragma warning disable 618
-            var webView = new WebViewCompatible();
+            var webView = new WebView2();
             window.Content = webView;
 
             webView.NavigationStarting += (sender, e) =>
             {
-#if NET6_0
                 if (e.Uri.StartsWith(options.EndUrl))
-#else
-                if (e.Uri.AbsoluteUri.StartsWith(options.EndUrl))
-#endif
                 {
                     tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.Success, Response = e.Uri.ToString() });
                     if (_shouldCloseWindow)
@@ -82,12 +74,8 @@ namespace Auth0.OidcClient
 
             window.Show();
 
-#if NET6_0
             await webView.EnsureCoreWebView2Async();
             webView.CoreWebView2.Navigate(options.StartUrl);
-#else
-            webView.Navigate(options.StartUrl);
-#endif
 
             return await tcs.Task;
         }

--- a/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
+++ b/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
@@ -31,9 +31,7 @@
 		<When Condition="'$(TargetFramework)'!='net6.0-windows'">
 			<ItemGroup>
 				<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-				<PackageReference Include="Microsoft.Toolkit.Forms.UI.Controls.WebView">
-					<Version>6.1.2</Version>
-				</PackageReference>
+				<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1823.32" />
 			</ItemGroup>
 		</When>
 		<When Condition="'$(TargetFramework)'=='net6.0-windows'">

--- a/src/Auth0.OidcClient.WinForms/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WinForms/WebViewBrowser.cs
@@ -1,9 +1,5 @@
 ﻿using IdentityModel.OidcClient.Browser;
-#if NET6_0
-using WebViewCompatible = Microsoft.Web.WebView2.WinForms.WebView2;
-#else
-using Microsoft.Toolkit.Forms.UI.Controls;
-#endif
+using Microsoft.Web.WebView2.WinForms;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -52,15 +48,11 @@ namespace Auth0.OidcClient
 
             var window = _formFactory();
             #pragma warning disable 618
-            var webView = new WebViewCompatible { Dock = DockStyle.Fill };
+            var webView = new WebView2 { Dock = DockStyle.Fill };
 
             webView.NavigationStarting += (sender, e) =>
             {
-#if NET6_0
                 if (e.Uri.StartsWith(options.EndUrl))
-#else
-                if (e.Uri.AbsoluteUri.StartsWith(options.EndUrl))
-#endif
                 {
                     tcs.SetResult(new BrowserResult { ResultType = BrowserResultType.Success, Response = e.Uri.ToString() });
                     window.Close();
@@ -77,12 +69,8 @@ namespace Auth0.OidcClient
 
             window.Show();
 
-#if NET6_0
             await webView.EnsureCoreWebView2Async();
             webView.CoreWebView2.Navigate(options.StartUrl);
-#else
-            webView.Navigate(options.StartUrl);
-#endif
 
             return await tcs.Task;
         }


### PR DESCRIPTION
### Changes

Drop support for WebView on WPF and Winforms as this has been deprecated in favor of WebView2. We will now default to WebView2 on .NET Framework as well.

### References

- https://www.nuget.org/packages/Microsoft.Toolkit.Wpf.UI.Controls.WebView
- https://www.nuget.org/packages/Microsoft.Toolkit.Forms.UI.Controls.WebView

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
