### PR TITLE
Release 4.0.0

### DIFF
--- a/nuget/Auth0.OidcClient.Android.nuspec
+++ b/nuget/Auth0.OidcClient.Android.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.Android</id>
-    <version>3.5.0</version>
+    <version>4.0.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Xamarin Android apps. Relies on deprecated support libraries from Google, use Auth0.OidcClient.AndroidX instead.</description>
     <releaseNotes>
+    Version 4.0.0
+      - Remove support for Client Secret and HS256
+
     Version 3.5.0
       - Set Android Target Framework Version to v11
     
@@ -129,7 +132,7 @@
     <tags>Auth0 OIDC Android Xamarin</tags>
     <dependencies>
       <group targetFramework="MonoAndroid11">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.Android.nuspec
+++ b/nuget/Auth0.OidcClient.Android.nuspec
@@ -13,7 +13,7 @@
     <description>Auth0 OIDC Client for Xamarin Android apps. Relies on deprecated support libraries from Google, use Auth0.OidcClient.AndroidX instead.</description>
     <releaseNotes>
     Version 4.0.0
-      - Remove support for Client Secret and HS256
+      - Remove support for Client Secret
 
     Version 3.5.0
       - Set Android Target Framework Version to v11

--- a/nuget/Auth0.OidcClient.AndroidX.nuspec
+++ b/nuget/Auth0.OidcClient.AndroidX.nuspec
@@ -13,7 +13,7 @@
     <description>Auth0 OIDC Client for Xamarin AndroidX apps</description>
     <releaseNotes>
     Version 4.0.0
-      - Remove support for Client Secret and HS256
+      - Remove support for Client Secret
 
     Version 3.5.0
       - Set Android Target Framework Version to v11

--- a/nuget/Auth0.OidcClient.AndroidX.nuspec
+++ b/nuget/Auth0.OidcClient.AndroidX.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.AndroidX</id>
-    <version>3.5.0</version>
+    <version>4.0.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Xamarin AndroidX apps</description>
     <releaseNotes>
+    Version 4.0.0
+      - Remove support for Client Secret and HS256
+
     Version 3.5.0
       - Set Android Target Framework Version to v11
       - Support .NET6 and above
@@ -63,7 +66,7 @@
     <tags>Auth0 OIDC Android Xamarin</tags>
     <dependencies>
       <group targetFramework="MonoAndroid11">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.Core.nuspec
+++ b/nuget/Auth0.OidcClient.Core.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.Core</id>
-    <version>3.4.1</version>
+    <version>4.0.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for native apps</description>
     <releaseNotes>
+    Version 4.0.0
+      - Remove support for Client Secret and HS256
+
     Version 3.4.1
       - Do not lowercase org_name claim
 

--- a/nuget/Auth0.OidcClient.Core.nuspec
+++ b/nuget/Auth0.OidcClient.Core.nuspec
@@ -13,7 +13,7 @@
     <description>Auth0 OIDC Client for native apps</description>
     <releaseNotes>
     Version 4.0.0
-      - Remove support for Client Secret and HS256
+      - Remove support for Client Secret
 
     Version 3.4.1
       - Do not lowercase org_name claim

--- a/nuget/Auth0.OidcClient.UWP.nuspec
+++ b/nuget/Auth0.OidcClient.UWP.nuspec
@@ -13,7 +13,7 @@
     <description>Auth0 OIDC Client for Universal Windows Platform (UWP) apps</description>
     <releaseNotes>
     Version 4.0.0
-      - Remove support for Client Secret and HS256
+      - Remove support for Client Secret
 
     Version 3.4.1
       - Do not lowercase org_name claim

--- a/nuget/Auth0.OidcClient.UWP.nuspec
+++ b/nuget/Auth0.OidcClient.UWP.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.UWP</id>
-    <version>3.4.1</version>
+    <version>4.0.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Universal Windows Platform (UWP) apps</description>
     <releaseNotes>
+    Version 4.0.0
+      - Remove support for Client Secret and HS256
+
     Version 3.4.1
       - Do not lowercase org_name claim
   
@@ -107,7 +110,7 @@
     <tags>Auth0 OIDC UWP Windows10</tags>
     <dependencies>
       <group targetFramework="uap10.0.16299">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.WPF.nuspec
+++ b/nuget/Auth0.OidcClient.WPF.nuspec
@@ -13,7 +13,7 @@
     <description>Auth0 OIDC Client for WPF apps</description>
     <releaseNotes>
     Version 4.0.0
-      - Remove support for Client Secret and HS256
+      - Remove support for Client Secret
       - Drop support for WebView for WPF and Winforms and default to WebView2
 
     Version 3.5.0

--- a/nuget/Auth0.OidcClient.WPF.nuspec
+++ b/nuget/Auth0.OidcClient.WPF.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.WPF</id>
-    <version>3.5.0</version>
+    <version>4.0.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for WPF apps</description>
     <releaseNotes>
+    Version 4.0.0
+      - Remove support for Client Secret and HS256
+      - Drop support for WebView for WPF and Winforms and default to WebView2
+
     Version 3.5.0
       - Add support for .NET6+ by supporting WebView2
 
@@ -126,15 +130,15 @@
     <tags>Auth0 OIDC WPF</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.0" />
         <dependency id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.0" />
         <dependency id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
       </group>
       <group targetFramework="net6.0-windows7.0">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.0" />
         <dependency id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
       </group>
     </dependencies>

--- a/nuget/Auth0.OidcClient.WinForms.nuspec
+++ b/nuget/Auth0.OidcClient.WinForms.nuspec
@@ -13,7 +13,7 @@
     <description>Auth0 OIDC Client for WinForms apps</description>
     <releaseNotes>
     Version 4.0.0
-      - Remove support for Client Secret and HS256
+      - Remove support for Client Secret
       - Drop support for WebView for WPF and Winforms and default to WebView2
 
     Version 3.5.0

--- a/nuget/Auth0.OidcClient.WinForms.nuspec
+++ b/nuget/Auth0.OidcClient.WinForms.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.WinForms</id>
-    <version>3.5.0</version>
+    <version>4.0.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for WinForms apps</description>
     <releaseNotes>
+    Version 4.0.0
+      - Remove support for Client Secret and HS256
+      - Drop support for WebView for WPF and Winforms and default to WebView2
+
     Version 3.5.0
       - Add support for .NET6+ by supporting WebView2
 
@@ -119,15 +123,15 @@
     <tags>Auth0 OIDC WinForms</tags>
     <dependencies>
       <group targetFramework="net462">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.0" />
         <dependency id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
       </group>
       <group targetFramework="netcoreapp3.1">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.0" />
         <dependency id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
       </group>
       <group targetFramework="net6.0-windows7.0">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.0" />
         <dependency id="Microsoft.Web.WebView2" version="1.0.1823.32"/>
       </group>
     </dependencies>

--- a/nuget/Auth0.OidcClient.iOS.nuspec
+++ b/nuget/Auth0.OidcClient.iOS.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.iOS</id>
-    <version>3.6.0</version>
+    <version>4.0.0</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for Xamarin iOS apps</description>
     <releaseNotes>
+    Version 4.0.0
+      - Remove support for Client Secret and HS256
+
     Version 3.6.0
       - Support .NET6 and above
 
@@ -110,7 +113,7 @@
     <tags>Auth0 OIDC iOS Xamarin</tags>
     <dependencies>
       <group targetFramework="Xamarin.iOS10">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.0" />
       </group>
     </dependencies>
   </metadata>

--- a/nuget/Auth0.OidcClient.iOS.nuspec
+++ b/nuget/Auth0.OidcClient.iOS.nuspec
@@ -13,7 +13,7 @@
     <description>Auth0 OIDC Client for Xamarin iOS apps</description>
     <releaseNotes>
     Version 4.0.0
-      - Remove support for Client Secret and HS256
+      - Remove support for Client Secret
 
     Version 3.6.0
       - Support .NET6 and above


### PR DESCRIPTION
**Breaking Changes**
- Remove support for Client Secret [\#304](https://github.com/auth0/auth0-oidc-client-net/pull/304) ([frederikprijck](https://github.com/frederikprijck))
- Drop support for WebView for WPF and Winforms and default to WebView2 [\#308](https://github.com/auth0/auth0-oidc-client-net/pull/308) ([frederikprijck](https://github.com/frederikprijck))

Note: If you are not using a Client Secret, or using WPF/Winforms on .NET6+, there should be no breaking change. The breaking changes are only for those using Client Secrets, or those using WPF/Winforms on the legacy .NET Framework (so not .NET).