### PR TITLE
Bump Microsoft.IdentityModel.Protocols.OpenIdConnect

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Install .NET Android and iOS workload
         run: dotnet workload install android ios maui
 
-      - name: Log
-        run: dotnet workload list
-
       - name: Setup NuGet
         uses: nuget/setup-nuget@v1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install .NET Android and iOS workload
         run: dotnet workload install android ios maui
 
+      - name: Log
+        run: dotnet workload list
+
       - name: Setup NuGet
         uses: nuget/setup-nuget@v1
 

--- a/nuget/Auth0.OidcClient.Android.nuspec
+++ b/nuget/Auth0.OidcClient.Android.nuspec
@@ -137,8 +137,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\src\Auth0.OidcClient.Android\bin\Release\monoandroid11.0\Auth0.OidcClient.dll" target="lib\MonoAndroid11" />
-    <file src="..\src\Auth0.OidcClient.Android\bin\Release\monoandroid11.0\Auth0.OidcClient.xml" target="lib\MonoAndroid11" />
+    <file src="..\src\Auth0.OidcClient.Android\bin\Release\monoandroid12.0\Auth0.OidcClient.dll" target="lib\MonoAndroid12" />
+    <file src="..\src\Auth0.OidcClient.Android\bin\Release\monoandroid12.0\Auth0.OidcClient.xml" target="lib\MonoAndroid12" />
     <file src="..\build\Auth0Icon.png" />
   </files>
 </package>

--- a/nuget/Auth0.OidcClient.AndroidX.nuspec
+++ b/nuget/Auth0.OidcClient.AndroidX.nuspec
@@ -71,8 +71,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\monoandroid11.0\Auth0.OidcClient.dll" target="lib\MonoAndroid11" />
-    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\monoandroid11.0\Auth0.OidcClient.xml" target="lib\MonoAndroid11" />
+    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\monoandroid12.0\Auth0.OidcClient.dll" target="lib\MonoAndroid12" />
+    <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\monoandroid12.0\Auth0.OidcClient.xml" target="lib\MonoAndroid12" />
     <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\net6.0-android\Auth0.OidcClient.dll" target="lib\net6.0-android29.0" />
     <file src="..\src\Auth0.OidcClient.AndroidX\bin\Release\net6.0-android\Auth0.OidcClient.xml" target="lib\net6.0-android29.0" />
     <file src="..\build\Auth0Icon.png" />

--- a/nuget/Auth0.OidcClient.Core.nuspec
+++ b/nuget/Auth0.OidcClient.Core.nuspec
@@ -100,7 +100,7 @@
     <dependencies>
       <group targetFramework="netstandard2.0">
         <dependency id="IdentityModel.OidcClient" version="5.2.1" />
-        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.12.2" />
+        <dependency id="Microsoft.IdentityModel.Protocols.OpenIdConnect" version="6.34.0" />
       </group>
     </dependencies>
   </metadata>

--- a/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
+++ b/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras/3.0.44">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid11.0</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid12.0</TargetFrameworks>
     <RootNamespace>Auth0.OidcClient</RootNamespace>
     <AssemblyName>Auth0.OidcClient</AssemblyName>
     <Product>Auth0.OidcClient</Product>
@@ -12,7 +12,7 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <DefineConstants>$(DefineConstants);</DefineConstants>    
     <LangVersion>default</LangVersion>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
   </PropertyGroup>
    <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugType>portable</DebugType>

--- a/src/Auth0.OidcClient.AndroidX/Auth0.OidcClient.AndroidX.csproj
+++ b/src/Auth0.OidcClient.AndroidX/Auth0.OidcClient.AndroidX.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Xamarin.Legacy.Sdk/0.2.0-alpha4">
   <PropertyGroup>
-    <TargetFrameworks>MonoAndroid11.0;net6.0-android</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid12.0;net6.0-android</TargetFrameworks>
     <RootNamespace>Auth0.OidcClient</RootNamespace>
     <AssemblyName>Auth0.OidcClient</AssemblyName>
     <Product>Auth0.OidcClient</Product>

--- a/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
+++ b/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
@@ -14,6 +14,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />
-    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.12.2" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.34.0" />
     </ItemGroup>
 </Project>

--- a/test/Android/Android.csproj
+++ b/test/Android/Android.csproj
@@ -15,7 +15,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v12.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>


### PR DESCRIPTION
Fix a Snyk issue regarding `Microsoft.IdentityModel.Protocols.OpenIdConnect`.

```
✗ Resource Exhaustion [Medium Severity][https://security.snyk.io/vuln/SNYK-DOTNET-MICROSOFTIDENTITYMODELJSONWEBTOKENS-6148656] in Microsoft.IdentityModel.JsonWebTokens@6.12.2
    introduced by Microsoft.IdentityModel.Protocols.OpenIdConnect@6.12.2 > System.IdentityModel.Tokens.Jwt@6.12.2 > Microsoft.IdentityModel.JsonWebTokens@6.12.2
  This issue was fixed in versions: 5.7.0, 6.34.0, 7.1.2
✗ Resource Exhaustion [Medium Severity][https://security.snyk.io/vuln/SNYK-DOTNET-SYSTEMIDENTITYMODELTOKENSJWT-[61](https://github.com/auth0/auth0-oidc-client-net/actions/runs/8821836705/job/24219430757?pr=324#step:11:62)48655] in System.IdentityModel.Tokens.Jwt@6.12.2
    introduced by Microsoft.IdentityModel.Protocols.OpenIdConnect@6.12.2 > System.IdentityModel.Tokens.Jwt@6.12.2
  This issue was fixed in versions: 5.7.0, 6.34.0, 7.1.2
```

Also bump Android to 32 to fix CI, which should be fine as it's the lowest supported version as per https://dotnet.microsoft.com/en-us/platform/support/policy/xamarin