### PR TITLE
Release MAUI v1.0.1

### DIFF
--- a/nuget/Auth0.OidcClient.Core.nuspec
+++ b/nuget/Auth0.OidcClient.Core.nuspec
@@ -3,7 +3,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.Core</id>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -12,6 +12,9 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for native apps</description>
     <releaseNotes>
+    Version 4.0.1
+      - Update Microsoft.IdentityModel.Protocols.OpenIdConnect
+
     Version 4.0.0
       - Remove support for Client Secret
 

--- a/nuget/Auth0.OidcClient.MAUI.nuspec
+++ b/nuget/Auth0.OidcClient.MAUI.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Auth0.OidcClient.MAUI</id>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <authors>Auth0</authors>
     <owners>Auth0</owners>
     <license type="expression">Apache-2.0</license>
@@ -11,6 +11,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Auth0 OIDC Client for MAUI apps</description>
     <releaseNotes>
+    Version 1.0.1
+      - Add net-6.0 target to Auth0 MAUI NuGet package.
+      - Bump Auth0.OidcClient.Core to v4, removing support for ClientSecret
+
     Version 1.0.0
       - Initial release for adding support for MAUI on Android, iOS, macOS, and Windows.
 
@@ -25,25 +29,25 @@
     <readme>README.md</readme>
     <dependencies>
       <group targetFramework="net6.0">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.1" />
         <dependency id="IdentityModel.OidcClient" version="5.2.1" />
       </group>
       <group targetFramework="net6.0-android29.0">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.1" />
         <dependency id="IdentityModel.OidcClient" version="5.2.1" />
       </group>
       <group targetFramework="net6.0-ios13.0">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.1" />
         <dependency id="IdentityModel.OidcClient" version="5.2.1" />
         <dependency id="System.Runtime.InteropServices.NFloat.Internal" version="6.0.1" />
       </group>
       <group targetFramework="net6.0-maccatalyst14.0">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.1" />
         <dependency id="IdentityModel.OidcClient" version="5.2.1" />
         <dependency id="System.Runtime.InteropServices.NFloat.Internal" version="6.0.1" />
       </group>
       <group targetFramework="net6.0-windows10.0.19041">
-        <dependency id="Auth0.OidcClient.Core" version="3.4.1" />
+        <dependency id="Auth0.OidcClient.Core" version="4.0.1" />
         <dependency id="IdentityModel.OidcClient" version="5.2.1" />
         <dependency id="Microsoft.WindowsAppSDK" version="1.2.221209.1" />
       </group>

--- a/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
+++ b/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
@@ -2,9 +2,9 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <RootNamespace>Auth0.OidcClient</RootNamespace>
-    <AssemblyVersion>3.4.1</AssemblyVersion>
-    <FileVersion>3.4.1</FileVersion>
-    <Version>3.4.1</Version>
+    <AssemblyVersion>4.0.1</AssemblyVersion>
+    <FileVersion>4.0.1</FileVersion>
+    <Version>4.0.1</Version>
     <Configurations>Release;Debug</Configurations>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">


### PR DESCRIPTION
- Add net-6.0 target to Auth0 MAUI NuGet package.
- Bump Auth0.OidcClient.Core to v4, removing support for ClientSecret

Note that this also bums `Auth0.OidcClient.Core` from v3 to v4, which is intentional. The only difference with v4 is that support for ClientSecret has been removed, which should not be available in client-SDKs to begin with, hence this being released as a patch fix.

Additionally, this also releases v4.0.1 of Auth0.OidcClient.Core, bumping `Microsoft.IdentityModel.Protocols.OpenIdConnect` to address a vulnerability.