### PR TITLE
ci:Use 'dotnet test' instead of vstest-action as workaround

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,8 +37,4 @@ jobs:
         run: msbuild Auth0.OidcClient.All.sln -t:rebuild -verbosity:diag -property:Configuration=Release
 
       - name: Tests
-        uses: microsoft/vstest-action@v1.0.0
-        with:
-          testAssembly: '**\bin\**\*UnitTests.dll'
-          searchFolder: '.\'
-          runInParallel: false
+        run: dotnet test **\bin\**\*UnitTests.dll


### PR DESCRIPTION
### Changes

Changes to use `dotnet test` instead of vs-test action as a workaround to avoid build failure.
Open [github issue](https://github.com/microsoft/vstest-action/issues/31) on vs-test action build failure 


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
