### PR TITLE
Replace IdentityModel Package with Duende.IdentityModel

### DIFF
--- a/src/Auth0.OidcClient.Android/AndroidBrowserBase.cs
+++ b/src/Auth0.OidcClient.Android/AndroidBrowserBase.cs
@@ -1,6 +1,6 @@
 ﻿using Android.App;
 using Android.Content;
-using IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.OidcClient.Browser;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
+++ b/src/Auth0.OidcClient.Android/Auth0.OidcClient.Android.csproj
@@ -46,9 +46,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient" Version="5.2.1">
-    </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="28.0.0.3">
-    </PackageReference>
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
+    <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="28.0.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Auth0.OidcClient.Android/Auth0Client.cs
+++ b/src/Auth0.OidcClient.Android/Auth0Client.cs
@@ -7,7 +7,7 @@ namespace Auth0.OidcClient
 {
     /// <summary>
     /// Primary class for performing authentication and authorization operations with Auth0 using the
-    /// underlying <see cref="IdentityModel.OidcClient.OidcClient"/>.
+    /// underlying <see cref="Duende.IdentityModel.OidcClient.OidcClient"/>.
     /// </summary>
     public class Auth0Client : Auth0ClientBase
     {

--- a/src/Auth0.OidcClient.Android/Auth0ClientActivity.cs
+++ b/src/Auth0.OidcClient.Android/Auth0ClientActivity.cs
@@ -1,6 +1,6 @@
 ﻿using Android.App;
 using Android.Content;
-using IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.OidcClient.Browser;
 
 namespace Auth0.OidcClient
 {

--- a/src/Auth0.OidcClient.Android/AutoSelectBrowser.cs
+++ b/src/Auth0.OidcClient.Android/AutoSelectBrowser.cs
@@ -1,5 +1,5 @@
 ﻿using Android.Content;
-using IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.OidcClient.Browser;
 
 namespace Auth0.OidcClient
 {

--- a/src/Auth0.OidcClient.Android/SystemBrowser.cs
+++ b/src/Auth0.OidcClient.Android/SystemBrowser.cs
@@ -1,5 +1,5 @@
 using Android.Content;
-using IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.OidcClient.Browser;
 
 namespace Auth0.OidcClient
 {

--- a/src/Auth0.OidcClient.AndroidX/Auth0.OidcClient.AndroidX.csproj
+++ b/src/Auth0.OidcClient.AndroidX/Auth0.OidcClient.AndroidX.csproj
@@ -39,9 +39,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient">
-      <Version>5.2.1</Version>
-    </PackageReference>
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
     <PackageReference Include="Xamarin.AndroidX.Browser">
       <Version>1.3.0.6</Version>
     </PackageReference>

--- a/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
+++ b/src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
@@ -13,7 +13,8 @@
     <AssemblyOriginatorKeyFile>..\..\build\Auth0OidcClientStrongName.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="6.34.0" />
     </ItemGroup>
 </Project>

--- a/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientBase.cs
@@ -6,18 +6,19 @@ using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Auth0.OidcClient.Tokens;
-using IdentityModel.Client;
-using IdentityModel.OidcClient;
-using IdentityModel.OidcClient.Browser;
-using IdentityModel.OidcClient.Results;
-using static IdentityModel.OidcClient.OidcClientOptions;
+
+using Duende.IdentityModel.Client;
+using Duende.IdentityModel.OidcClient;
+using Duende.IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.OidcClient.Results;
 
 namespace Auth0.OidcClient
 {
     /// <summary>
     /// Base class for performing authentication and authorization operations with Auth0 using the
-    /// underlying <see cref="IdentityModel.OidcClient.OidcClient"/>.
+    /// underlying <see cref="Duende.IdentityModel.OidcClient.OidcClient"/>.
     /// </summary>
     public abstract class Auth0ClientBase : IAuth0Client
     {
@@ -25,12 +26,12 @@ namespace Auth0.OidcClient
         private readonly IdTokenValidator _idTokenValidator;
         private readonly Auth0ClientOptions _options;
         private readonly string _userAgent;
-        private IdentityModel.OidcClient.OidcClient _oidcClient;
-        private IdentityModel.OidcClient.OidcClient OidcClient
+        private Duende.IdentityModel.OidcClient.OidcClient _oidcClient;
+        private Duende.IdentityModel.OidcClient.OidcClient OidcClient
         {
             get
             {
-                return _oidcClient ?? (_oidcClient = new IdentityModel.OidcClient.OidcClient(CreateOidcClientOptions(_options)));
+                return _oidcClient ?? (_oidcClient = new Duende.IdentityModel.OidcClient.OidcClient(CreateOidcClientOptions(_options)));
             }
         }
 

--- a/src/Auth0.OidcClient.Core/Auth0ClientOptions.cs
+++ b/src/Auth0.OidcClient.Core/Auth0ClientOptions.cs
@@ -1,4 +1,4 @@
-﻿using IdentityModel.OidcClient.Browser;
+﻿using Duende.IdentityModel.OidcClient.Browser;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Net.Http;

--- a/src/Auth0.OidcClient.Core/IAuth0Client.cs
+++ b/src/Auth0.OidcClient.Core/IAuth0Client.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using IdentityModel.OidcClient;
-using IdentityModel.OidcClient.Browser;
-using IdentityModel.OidcClient.Results;
+using Duende.IdentityModel.OidcClient;
+using Duende.IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.OidcClient.Results;
 
 namespace Auth0.OidcClient
 {
     /// <summary>
     /// Interface for performing authentication and authorization operations with Auth0 using the
-    /// underlying <see cref="IdentityModel.OidcClient.OidcClient"/>.
+    /// underlying <see cref="Duende.IdentityModel.OidcClient.OidcClient"/>.
     /// </summary>
     public interface IAuth0Client
     {
@@ -56,7 +56,7 @@ namespace Auth0.OidcClient
         /// Generates a new set of tokens based on a refresh token. 
         /// </summary>
         /// <param name="refreshToken">Refresh token which was issued during the authorization flow, or subsequent
-        /// calls to <see cref="IdentityModel.OidcClient.OidcClient.RefreshTokenAsync"/>.</param>
+        /// calls to <see cref="Duende.IdentityModel.OidcClient.OidcClient.RefreshTokenAsync"/>.</param>
         /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> that can be used to cancel the request.</param>
         /// <returns>A <see cref="RefreshTokenResult"/> with the refreshed tokens.</returns>
         Task<RefreshTokenResult> RefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default);
@@ -65,7 +65,7 @@ namespace Auth0.OidcClient
         /// Generates a new set of tokens based on a refresh token. 
         /// </summary>
         /// <param name="refreshToken">Refresh token which was issued during the authorization flow, or subsequent
-        /// calls to <see cref="IdentityModel.OidcClient.OidcClient.RefreshTokenAsync"/>.</param>
+        /// calls to <see cref="Duende.IdentityModel.OidcClient.OidcClient.RefreshTokenAsync"/>.</param>
         /// <param name="extraParameters">Optional extra parameters that need to be passed to the endpoint.</param>
         /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> that can be used to cancel the request.</param>
         /// <returns>A <see cref="RefreshTokenResult"/> with the refreshed tokens.</returns>
@@ -75,7 +75,7 @@ namespace Auth0.OidcClient
         /// Generates a new set of tokens based on a refresh token. 
         /// </summary>
         /// <param name="refreshToken">Refresh token which was issued during the authorization flow, or subsequent
-        /// calls to <see cref="IdentityModel.OidcClient.OidcClient.RefreshTokenAsync"/>.</param>
+        /// calls to <see cref="Duende.IdentityModel.OidcClient.OidcClient.RefreshTokenAsync"/>.</param>
         /// <param name="scope">Space separated list of the requested scopes.</param>
         /// <param name="extraParameters">Optional extra parameters that need to be passed to the endpoint.</param>
         /// <param name="cancellationToken">Optional <see cref="CancellationToken"/> that can be used to cancel the request.</param>

--- a/src/Auth0.OidcClient.MAUI/Auth0.OidcClient.MAUI.csproj
+++ b/src/Auth0.OidcClient.MAUI/Auth0.OidcClient.MAUI.csproj
@@ -29,7 +29,7 @@
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 	</PropertyGroup>
 	<ItemGroup>
-	  <PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />
+	  <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
 	</ItemGroup>
 	<ItemGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">
 	  <ProjectReference Include="..\Auth0.OidcClient.MAUI.Platforms.Windows\Auth0.OidcClient.MAUI.Platforms.Windows.csproj" />

--- a/src/Auth0.OidcClient.MAUI/Auth0Client.cs
+++ b/src/Auth0.OidcClient.MAUI/Auth0Client.cs
@@ -2,7 +2,7 @@
 
 /// <summary>
 /// Primary class for performing authentication and authorization operations with Auth0 using the
-/// underlying <see cref="IdentityModel.OidcClient.OidcClient"/>.
+/// underlying <see cref="Duende.IdentityModel.OidcClient.OidcClient"/>.
 /// </summary>
 public class Auth0Client : Auth0ClientBase
 {

--- a/src/Auth0.OidcClient.MAUI/WebAuthenticatorBrowser.cs
+++ b/src/Auth0.OidcClient.MAUI/WebAuthenticatorBrowser.cs
@@ -1,7 +1,7 @@
 ﻿namespace Auth0.OidcClient;
 
-using IdentityModel.OidcClient.Browser;
-using IdentityModel.Client;
+using Duende.IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.Client;
 
 /// <summary>
 /// Implements the Browser <see cref="IBrowser"/> using <see cref="WebAuthenticator"/> for MAUI.

--- a/src/Auth0.OidcClient.UWP/Auth0.OidcClient.UWP.csproj
+++ b/src/Auth0.OidcClient.UWP/Auth0.OidcClient.UWP.csproj
@@ -39,6 +39,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient" Version="5.2.1" />
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Auth0.OidcClient.UWP/Auth0Client.cs
+++ b/src/Auth0.OidcClient.UWP/Auth0Client.cs
@@ -5,7 +5,7 @@ namespace Auth0.OidcClient
 {
     /// <summary>
     /// Primary class for performing authentication and authorization operations with Auth0 using the
-    /// underlying <see cref="IdentityModel.OidcClient.OidcClient"/>.
+    /// underlying <see cref="Duende.IdentityModel.OidcClient.OidcClient"/>.
     /// </summary>
     public class Auth0Client : Auth0ClientBase
     {

--- a/src/Auth0.OidcClient.UWP/WebAuthenticationBrokerBrowser.cs
+++ b/src/Auth0.OidcClient.UWP/WebAuthenticationBrokerBrowser.cs
@@ -1,4 +1,4 @@
-﻿using IdentityModel.OidcClient.Browser;
+﻿using Duende.IdentityModel.OidcClient.Browser;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Auth0.OidcClient.UWP/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.UWP/WebViewBrowser.cs
@@ -1,4 +1,4 @@
-﻿using IdentityModel.OidcClient.Browser;
+﻿using Duende.IdentityModel.OidcClient.Browser;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
+++ b/src/Auth0.OidcClient.WPF/Auth0.OidcClient.WPF.csproj
@@ -23,9 +23,7 @@
     <ProjectReference Include="..\Auth0.OidcClient.Core\Auth0.OidcClient.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient">
-      <Version>5.2.1</Version>
-    </PackageReference>
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
   </ItemGroup>
 	<Choose>
 		<When Condition="'$(TargetFramework)'!='net6.0-windows'">

--- a/src/Auth0.OidcClient.WPF/Auth0Client.cs
+++ b/src/Auth0.OidcClient.WPF/Auth0Client.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Primary class for performing authentication and authorization operations with Auth0 using the
-    /// underlying <see cref="IdentityModel.OidcClient.OidcClient"/>.
+    /// underlying <see cref="Duende.IdentityModel.OidcClient.OidcClient"/>.
     /// </summary>
     public class Auth0Client : Auth0ClientBase
     {

--- a/src/Auth0.OidcClient.WPF/WebBrowserBrowser.cs
+++ b/src/Auth0.OidcClient.WPF/WebBrowserBrowser.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
-using IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.OidcClient.Browser;
 
 namespace Auth0.OidcClient
 {

--- a/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WPF/WebViewBrowser.cs
@@ -1,4 +1,4 @@
-﻿using IdentityModel.OidcClient.Browser;
+﻿using Duende.IdentityModel.OidcClient.Browser;
 using Microsoft.Web.WebView2.Wpf;
 using System;
 using System.Threading;

--- a/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
+++ b/src/Auth0.OidcClient.WinForms/Auth0.OidcClient.WinForms.csproj
@@ -23,9 +23,7 @@
     <ProjectReference Include="..\Auth0.OidcClient.Core\Auth0.OidcClient.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient">
-      <Version>5.2.1</Version>
-    </PackageReference>
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
   </ItemGroup>
   <Choose>
 		<When Condition="'$(TargetFramework)'!='net6.0-windows'">

--- a/src/Auth0.OidcClient.WinForms/Auth0Client.cs
+++ b/src/Auth0.OidcClient.WinForms/Auth0Client.cs
@@ -2,7 +2,7 @@
 {
     /// <summary>
     /// Primary class for performing authentication and authorization operations with Auth0 using the
-    /// underlying <see cref="IdentityModel.OidcClient.OidcClient"/>.
+    /// underlying <see cref="Duende.IdentityModel.OidcClient.OidcClient"/>.
     /// </summary>
     public class Auth0Client : Auth0ClientBase
     {

--- a/src/Auth0.OidcClient.WinForms/WebBrowserBrowser.cs
+++ b/src/Auth0.OidcClient.WinForms/WebBrowserBrowser.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Brock Allen & Dominick Baier. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-using IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.OidcClient.Browser;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Auth0.OidcClient.WinForms/WebViewBrowser.cs
+++ b/src/Auth0.OidcClient.WinForms/WebViewBrowser.cs
@@ -1,4 +1,4 @@
-﻿using IdentityModel.OidcClient.Browser;
+﻿using Duende.IdentityModel.OidcClient.Browser;
 using Microsoft.Web.WebView2.WinForms;
 using System;
 using System.Threading;

--- a/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/ASWebAuthenticationSessionBrowser.cs
@@ -1,6 +1,6 @@
 ﻿using AuthenticationServices;
 using Foundation;
-using IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.OidcClient.Browser;
 using System.Threading;
 using System.Threading.Tasks;
 using UIKit;

--- a/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
+++ b/src/Auth0.OidcClient.iOS/Auth0.OidcClient.iOS.csproj
@@ -39,8 +39,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient">
-      <Version>5.2.1</Version>
-    </PackageReference>
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Auth0.OidcClient.iOS/Auth0Client.cs
+++ b/src/Auth0.OidcClient.iOS/Auth0Client.cs
@@ -4,7 +4,7 @@ namespace Auth0.OidcClient
 {
     /// <summary>
     /// Primary class for performing authentication and authorization operations with Auth0 using the
-    /// underlying <see cref="IdentityModel.OidcClient.OidcClient"/>.
+    /// underlying <see cref="Duende.IdentityModel.OidcClient.OidcClient"/>.
     /// </summary>
     public class Auth0Client : Auth0ClientBase
     {

--- a/src/Auth0.OidcClient.iOS/AutoSelectBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/AutoSelectBrowser.cs
@@ -1,4 +1,4 @@
-﻿using IdentityModel.OidcClient.Browser;
+﻿using Duende.IdentityModel.OidcClient.Browser;
 using System.Threading;
 using System.Threading.Tasks;
 using UIKit;

--- a/src/Auth0.OidcClient.iOS/SFAuthenticationSessionBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/SFAuthenticationSessionBrowser.cs
@@ -1,5 +1,5 @@
 ﻿using Foundation;
-using IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.OidcClient.Browser;
 using SafariServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Auth0.OidcClient.iOS/SFSafariViewControllerBrowser.cs
+++ b/src/Auth0.OidcClient.iOS/SFSafariViewControllerBrowser.cs
@@ -1,5 +1,5 @@
 ﻿using Foundation;
-using IdentityModel.OidcClient.Browser;
+using Duende.IdentityModel.OidcClient.Browser;
 using SafariServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Auth0.OidcClient.iOS/iOSBrowserBase.cs
+++ b/src/Auth0.OidcClient.iOS/iOSBrowserBase.cs
@@ -1,4 +1,4 @@
-﻿using IdentityModel.OidcClient.Browser;
+﻿using Duende.IdentityModel.OidcClient.Browser;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/test/Android/Android.csproj
+++ b/test/Android/Android.csproj
@@ -88,9 +88,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient">
-      <Version>5.2.1</Version>
-    </PackageReference>
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/UWP/UWP.csproj
+++ b/test/UWP/UWP.csproj
@@ -140,9 +140,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient">
-      <Version>5.2.1</Version>
-    </PackageReference>
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.12</Version>
     </PackageReference>

--- a/test/WPF/WPF.csproj
+++ b/test/WPF/WPF.csproj
@@ -106,9 +106,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient">
-      <Version>5.2.1</Version>
-    </PackageReference>
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/WinForms/WinForms.csproj
+++ b/test/WinForms/WinForms.csproj
@@ -122,9 +122,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient">
-      <Version>5.2.1</Version>
-    </PackageReference>
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/test/iOS/iOS.csproj
+++ b/test/iOS/iOS.csproj
@@ -128,9 +128,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="IdentityModel.OidcClient">
-      <Version>5.2.1</Version>
-    </PackageReference>
+    <PackageReference Include="Duende.IdentityModel.OidcClient" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Media.xcassets\AppIcons.appiconset\Contents.json">


### PR DESCRIPTION
### Changes
- `IdentityModel.OidcClient` package has been deprecated and re-branded as `Duende.IdentityModel.OidcClient` - More details [here](https://www.nuget.org/packages/IdentityModel.OidcClient/6.0.0#dependencies-body-tab).
- Added an explicit reference to `Microsoft.Extensions.Logging` `v6.0.0`
    - This was necessary to keep the default LoggerFactory behaviour intact. 
    - `IdentityModel.OidcClient` package had a transitive dependency on `Microsoft.Extensions.Logging` package and hence we did not need an explicit reference. This transitive dependency has been dropped in `Duende.IdentityModel.OidcClient` and hence the need for the explicit reference. We have ensured to refer a lower version (`v6.0.0`) to reduce the risk of version compatibility issues for users.
### References

Please include relevant links supporting this change such as a:

- [SDK-5826](https://auth0team.atlassian.net/browse/SDK-5826)
- [Package deprecation](https://www.nuget.org/packages/IdentityModel.OidcClient/6.0.0#dependencies-body-tab)
- #343 

### Testing

Tested the changes with our sample MAUI and UWP apps.

- [x] This change adds unit test coverage
- [x] This change adds integration test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed


[SDK-5826]: https://auth0team.atlassian.net/browse/SDK-5826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ