### PR TITLE
chore: Adds CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+@./CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# AI Agent Guidelines for auth0-oidc-client-net
+
+## Your Role
+
+You are a C# SDK engineer working on auth0-oidc-client-net. This repo provides Auth0 OIDC authentication for .NET desktop and mobile platforms via per-platform NuGet packages.
+
+---
+
+## Workspace Packages
+
+This is a .NET solution (MSBuild/NuGet) monorepo. **Build and test commands run at the solution root (`Auth0.OidcClient.All.sln`), not per package directory** — MSBuild resolves cross-project references automatically.
+
+| Package | Path | Purpose |
+|---------|------|---------|
+| Auth0.OidcClient.Core | `src/Auth0.OidcClient.Core` | Shared OIDC client logic, base class, token validation |
+| Auth0.OidcClient.AndroidX | `src/Auth0.OidcClient.AndroidX` | Android browser integration (Chrome Custom Tabs) |
+| Auth0.OidcClient.Android | `src/Auth0.OidcClient.Android` | Android legacy (deprecated; use AndroidX for new work) |
+| Auth0.OidcClient.iOS | `src/Auth0.OidcClient.iOS` | iOS browser integration (ASWebAuthenticationSession) |
+| Auth0.OidcClient.WPF | `src/Auth0.OidcClient.WPF` | WPF desktop browser integration |
+| Auth0.OidcClient.WinForms | `src/Auth0.OidcClient.WinForms` | WinForms desktop browser integration |
+| Auth0.OidcClient.UWP | `src/Auth0.OidcClient.UWP` | UWP Web Authentication Broker integration |
+| Auth0.OidcClient.MAUI | `src/Auth0.OidcClient.MAUI` | MAUI cross-platform browser integration |
+| Auth0.OidcClient.MAUI.Platforms.Windows | `src/Auth0.OidcClient.MAUI.Platforms.Windows` | MAUI Windows-specific platform implementation |
+
+`Auth0.OidcClient.Core` is the base; all platform packages take a `<ProjectReference>` on it — changes to Core can break all dependents.
+
+`Directory.Build.props` and `global.json` apply to every package; changing either affects the whole repo.
+
+---
+
+## Git Workflow
+
+See [references/git-workflow.md](references/git-workflow.md) for branch naming, commit messages, and PR conventions. Read when creating branches, writing commits, or opening PRs.

--- a/references/git-workflow.md
+++ b/references/git-workflow.md
@@ -1,0 +1,25 @@
+# Git Workflow
+
+## Branch Naming
+
+- `release/<package>-<version>` — release branches (e.g. `release/core-4.1.0`); merging a release branch into master triggers the NuGet publish workflow
+- `fix/<description>` — bug fixes
+- `feat/<description>` — new features
+
+## Commit Messages
+
+No enforced commit convention is detected. Keep messages short and descriptive. Reference issue numbers where applicable.
+
+## Pull Requests
+
+This repo is in the Auth0 org and has a local PR template (`.github/PULL_REQUEST_TEMPLATE.md`). Every PR must fill in:
+
+- **Changes** — what changed and why, including any API surface changes, deprecated methods, or behavior differences
+- **References** — links to support tickets, community posts, or issues
+- **Testing** — how reviewers can verify the change; check all boxes that apply (unit tests, integration tests, tested on latest platform)
+- **Checklist** — confirm you've read the Auth0 contribution and code-of-conduct guidelines, all tests pass, and all code guidelines in `CONTRIBUTING.md` are followed
+
+Key rules from `CONTRIBUTING.md`:
+- Maintain the existing minimum .NET framework/core support — do not raise the minimum target without prior discussion
+- Keep PRs focused; change the minimum number of lines to achieve your goal
+- Do not introduce breaking changes without prior discussion and approval

--- a/src/Auth0.OidcClient.Android/AGENTS.md
+++ b/src/Auth0.OidcClient.Android/AGENTS.md
@@ -1,0 +1,1 @@
+@./CLAUDE.md

--- a/src/Auth0.OidcClient.Android/CLAUDE.md
+++ b/src/Auth0.OidcClient.Android/CLAUDE.md
@@ -1,0 +1,56 @@
+# AI Agent Guidelines for Auth0.OidcClient.Android
+
+> ⚠️ **This package is deprecated.** It relies on Android support libraries deprecated by Google since 2019 and cannot target .NET 6+. For new Android work, use `Auth0.OidcClient.AndroidX`. Only accept bug fixes here; do not add new features.
+
+## Project Structure
+
+```
+src/Auth0.OidcClient.Android/
+└── Auth0.OidcClient.Android.csproj   # Legacy Android browser integration
+```
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Make surgical changes — touch only what the request requires
+- Keep `<Version>` in the `.csproj` in sync with `nuget/Auth0.OidcClient.Android.nuspec`
+- Update `README.md` if changing anything visible to consumers
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first**
+- Any change at all — this package is deprecated; confirm the fix cannot be applied to AndroidX instead
+
+### 🚫 Never Do
+
+- Add new features (deprecated; direct new work to AndroidX)
+- Commit secrets, API keys, or tokens
+- Log ID tokens, access tokens, or refresh tokens
+
+---
+
+## Security Considerations
+
+- **PKCE** — authentication flows use PKCE via `Auth0ClientBase`; do not bypass
+- **Token logging** — never log tokens
+
+---
+
+## Commands
+
+```bash
+nuget restore Auth0.OidcClient.All.sln
+msbuild Auth0.OidcClient.All.sln -t:rebuild -property:Configuration=Release -property:AndroidSdkDirectory=%ANDROID_SDK_ROOT%
+dotnet format --verify-no-changes
+```
+
+---
+
+## Docs Update Rules
+
+| File | What it covers | Exists |
+|------|---------------|--------|
+| `README.md` (repo root) | Installation note (deprecated, prefer AndroidX) | ✅ present |

--- a/src/Auth0.OidcClient.AndroidX/AGENTS.md
+++ b/src/Auth0.OidcClient.AndroidX/AGENTS.md
@@ -1,0 +1,1 @@
+@./CLAUDE.md

--- a/src/Auth0.OidcClient.AndroidX/CLAUDE.md
+++ b/src/Auth0.OidcClient.AndroidX/CLAUDE.md
@@ -1,0 +1,89 @@
+# AI Agent Guidelines for Auth0.OidcClient.AndroidX
+
+## Project Structure
+
+```
+src/Auth0.OidcClient.AndroidX/
+└── Auth0.OidcClient.AndroidX.csproj   # Android browser integration via Chrome Custom Tabs (AndroidX)
+test/Android/
+└── Android.csproj                      # Interactive test app (not automated unit tests)
+```
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run tests before committing: build the solution then `dotnet test **\bin\**\*UnitTests.dll`
+- Make surgical changes — touch only what the request requires
+- PascalCase for public types/members; `_camelCase` for private fields
+- Update `README.md` in the same PR when changing public API or configuration
+- When adding a new outbound Auth0 request path: route through `AppendTelemetry()` in `Auth0ClientBase`
+- Keep `<Version>` in the `.csproj` in sync with `nuget/Auth0.OidcClient.AndroidX.nuspec`
+- Prefer AndroidX over the legacy `Auth0.OidcClient.Android` package for any Android work
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first**
+- Adding new NuGet or Android dependencies
+- Changing Chrome Custom Tabs redirect/callback handling
+- Modifying `Directory.Build.props` or `global.json`
+- Raising minimum Android API level
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, or tokens
+- Log ID tokens, access tokens, or refresh tokens
+- Modify `obj/` or `bin/` output by hand
+- Add new features to the deprecated `Auth0.OidcClient.Android` package
+
+---
+
+## Security Considerations
+
+- **PKCE** — authentication flows use PKCE via `Auth0ClientBase`; do not bypass
+- **Token logging** — never log tokens in debug output or exceptions
+- **Custom URL scheme / app links** — callback URI must match the Auth0 dashboard allowed callback URLs; changes require updating both the Android manifest and Auth0 configuration
+
+---
+
+## Commands
+
+```bash
+# Requires Windows + Android SDK (CI sets ANDROID_SDK_ROOT)
+nuget restore Auth0.OidcClient.All.sln
+msbuild Auth0.OidcClient.All.sln -t:rebuild -property:Configuration=Release -property:AndroidSdkDirectory=%ANDROID_SDK_ROOT%
+dotnet test **\bin\**\*UnitTests.dll
+dotnet format --verify-no-changes
+```
+
+---
+
+## Testing
+
+No automated unit tests for this package. Validate via the `test/Android/` interactive test app on a device or emulator.
+
+---
+
+## Code Style
+
+PascalCase public members, `_camelCase` private fields, async methods end in `Async`. XML doc comments on public members.
+
+---
+
+## Common Pitfalls
+
+- Build requires Windows with the Android SDK installed; `ANDROID_SDK_ROOT` must be set and `platforms;android-31` + `build-tools;31.0.0` installed
+- `Auth0.OidcClient.Android` (legacy) cannot target .NET 6+; do not add features there — use AndroidX
+- Chrome Custom Tabs requires the intent filter in the host app's `AndroidManifest.xml`
+
+---
+
+## Docs Update Rules
+
+| File | What it covers | Exists |
+|------|---------------|--------|
+| `README.md` (repo root) | Installation (`Auth0.OidcClient.AndroidX`), Android quickstart link | ✅ present |
+
+Update `README.md` in the same PR when changing the public API or Android-specific configuration.

--- a/src/Auth0.OidcClient.Core/AGENTS.md
+++ b/src/Auth0.OidcClient.Core/AGENTS.md
@@ -1,0 +1,1 @@
+@./CLAUDE.md

--- a/src/Auth0.OidcClient.Core/CLAUDE.md
+++ b/src/Auth0.OidcClient.Core/CLAUDE.md
@@ -1,0 +1,125 @@
+# AI Agent Guidelines for Auth0.OidcClient.Core
+
+## Project Structure
+
+```
+src/Auth0.OidcClient.Core/
+├── Auth0ClientBase.cs          # Abstract base class; LoginAsync, LogoutAsync, GetUserInfoAsync, RefreshTokenAsync
+├── Auth0ClientOptions.cs       # Configuration options (Domain, ClientId, Scope, EnableTelemetry, …)
+├── IAuth0Client.cs             # Public interface
+├── AssemblyInfo.cs             # Strong-name key reference
+├── Tokens/
+│   ├── IdTokenValidator.cs     # Validates ID token against IdTokenRequirements
+│   ├── IdTokenRequirements.cs  # Expected issuer, audience, nonce, org, max_age
+│   ├── IdTokenValidationException.cs
+│   ├── AsymmetricSignatureVerifier.cs
+│   ├── ISignatureVerifier.cs
+│   └── Auth0ClaimNames.cs      # Auth0-specific JWT claim constants
+test/Auth0.OidcClient.Core.UnitTests/
+├── Tokens/
+│   ├── IdTokenValidatorTests.cs  # xUnit tests for token validation
+│   ├── JwtTokenFactory.cs        # Test helper for building JWTs
+│   └── NoSignatureVerifier.cs    # Test stub
+└── Data/
+    └── mockJsonWebKeySet.json    # Fixture for JWKS tests
+```
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run tests before committing: `dotnet test **\bin\**\*UnitTests.dll` (Windows) or build first then run
+- Make surgical changes — touch only what the request requires; do not refactor or reformat adjacent code
+- Follow PascalCase for public types and members; camelCase with underscore prefix for private fields (`_options`, `_userAgent`)
+- Add xUnit unit tests for new Core functionality in `test/Auth0.OidcClient.Core.UnitTests/`
+- Use typed exceptions following the project's error hierarchy (`IdTokenValidationException` for token errors)
+- Update `README.md` in the same PR when changing the public API, configuration options, or supported platforms
+- When adding a **new outbound request path to Auth0** (login, logout, userinfo, refresh, etc.): route it through the existing `AppendTelemetry()` method in `Auth0ClientBase.cs` so it carries the `auth0Client` parameter — preserve the `Auth0ClientOptions.EnableTelemetry` opt-out
+- Keep the version number in `Auth0.OidcClient.Core.csproj` (`<Version>`) in sync with the corresponding `nuget/Auth0.OidcClient.Core.nuspec`
+- Maintain the existing minimum .NET framework support (`netstandard2.0` for Core)
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first.** Never remove or rename public API members, change method signatures, or alter token validation behavior without explicit approval
+- Adding new NuGet dependencies
+- Raising the minimum `<TargetFrameworks>` or `netstandard` target
+- Modifying ID token validation logic in `Tokens/` (security-critical)
+- Changes to the telemetry payload structure in `Auth0ClientBase.cs`
+- Changes to `Directory.Build.props` or `global.json` (affects all packages)
+- Bumping dependency versions in `*.csproj` (especially `Duende.IdentityModel.OidcClient`, `Microsoft.IdentityModel.*`)
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, tokens, or the strong-name `.snk` key (already gitignored)
+- Log, print, or write ID tokens, access tokens, or refresh tokens to any output stream
+- Remove or skip failing tests without fixing the underlying issue
+- Modify `obj/`, `bin/` build output by hand
+- Break backward compatibility without explicit approval (see Ask First)
+- Hand-edit `nuget/*.nuspec` version numbers without also updating the corresponding `*.csproj`
+
+---
+
+## Security Considerations
+
+- **PKCE** — all authentication flows use PKCE via `Duende.IdentityModel.OidcClient`; do not bypass or disable it
+- **ID token validation** — `IdTokenValidator` validates issuer, audience, expiry, nonce, and signature on every login; do not skip or weaken these checks
+- **Token logging** — never log or expose access tokens, refresh tokens, or ID tokens in debug output, exceptions, or responses
+- **No token storage** — Core does not persist tokens; it returns them to the caller. Do not add persistent storage in Core
+- **Strong-name signing** — assemblies are strong-named via `build/Auth0OidcClientStrongName.snk`; do not disable signing on release builds
+- **Secret scanning** — do not commit `.env` files, credentials, or the `.snk` key file
+
+---
+
+## Commands
+
+See [references/commands.md](references/commands.md) for the full command reference. Read when you need to build, test, or format.
+
+Core commands (run from repo root on Windows — CI uses `windows-2022`):
+
+```bash
+# Restore NuGet packages
+nuget restore Auth0.OidcClient.All.sln
+
+# Build full solution
+msbuild Auth0.OidcClient.All.sln -t:rebuild -property:Configuration=Release
+
+# Run unit tests (after build)
+dotnet test **\bin\**\*UnitTests.dll
+
+# Format check
+dotnet format --verify-no-changes
+```
+
+---
+
+## Testing
+
+See [references/testing.md](references/testing.md) for testing conventions and mock patterns. Read when writing or reviewing tests.
+
+- **Framework:** xUnit 2.x + Moq 4.x
+- **Test location:** `test/Auth0.OidcClient.Core.UnitTests/`
+- The default `dotnet test **\bin\**\*UnitTests.dll` suite is unit-only — no credentials required
+
+---
+
+## Code Style
+
+PascalCase for public types, methods, and properties. Private fields use `_camelCase`. See [references/code-style.md](references/code-style.md) for naming conventions and patterns. Read when adding new types or reviewing style.
+
+CI-enforced: `dotnet build /warnaserror` treats warnings as errors — fix all warnings before committing.
+
+---
+
+## Common Pitfalls
+
+See [references/pitfalls.md](references/pitfalls.md) for platform and build gotchas. Read before making environment or dependency changes.
+
+---
+
+## Docs Update Rules
+
+See [references/docs-update.md](references/docs-update.md) for the tracked-docs inventory and code-to-docs mapping. Read before marking a PR complete.
+
+Update `README.md` in the same PR when changing the public API, configuration options, or installation instructions — do not defer.

--- a/src/Auth0.OidcClient.Core/references/code-style.md
+++ b/src/Auth0.OidcClient.Core/references/code-style.md
@@ -1,0 +1,49 @@
+# Code Style
+
+## Naming Conventions
+
+| Element | Convention | Example |
+|---------|-----------|---------|
+| Classes, interfaces, enums | PascalCase | `Auth0ClientBase`, `IAuth0Client` |
+| Public methods, properties | PascalCase | `LoginAsync`, `EnableTelemetry` |
+| Private fields | `_camelCase` | `_options`, `_userAgent`, `_oidcClient` |
+| Parameters, local variables | camelCase | `options`, `extraParameters` |
+| Async methods | suffix `Async` | `LoginAsync`, `LogoutAsync` |
+| Interfaces | prefix `I` | `IAuth0Client`, `ISignatureVerifier` |
+
+## Good vs Bad
+
+**✅ Good — follows project patterns:**
+
+```csharp
+private readonly Auth0ClientOptions _options;
+
+public async Task<LoginResult> LoginAsync(
+    object extraParameters = null,
+    CancellationToken cancellationToken = default)
+{
+    var finalExtraParameters = AppendTelemetry(extraParameters);
+    // ...
+    return await OidcClient.LoginAsync(loginRequest, cancellationToken);
+}
+```
+
+**❌ Bad — violates conventions:**
+
+```csharp
+private Auth0ClientOptions options; // missing underscore prefix
+
+public async Task<LoginResult> Login(  // missing Async suffix
+    object ExtraParameters = null)     // PascalCase parameter
+{
+    // ...
+}
+```
+
+## Patterns Used
+
+- **Template method** — `Auth0ClientBase` is abstract; platform packages subclass it and inject an `IBrowser` implementation
+- **Options object** — `Auth0ClientOptions` collects all configuration; passed to the constructor
+- **Async/await throughout** — all public methods are async; use `CancellationToken` as the last parameter
+- **XML doc comments** on all public members (`/// <summary>…`)
+- Strong-name signing on all assemblies (key in `build/Auth0OidcClientStrongName.snk`)

--- a/src/Auth0.OidcClient.Core/references/commands.md
+++ b/src/Auth0.OidcClient.Core/references/commands.md
@@ -1,0 +1,58 @@
+# Commands
+
+All commands run from the **repo root** on Windows (CI uses `windows-2022`). Mobile workloads (Android, iOS, MAUI) are not available on macOS/Linux via the full solution build.
+
+## Prerequisites
+
+```bash
+# Install .NET SDK (version from global.json)
+# Then install mobile workloads (required for Android/iOS/MAUI packages)
+dotnet workload install android ios maui
+dotnet workload update
+```
+
+## Build
+
+```bash
+# Restore NuGet packages (MSBuild/NuGet, not dotnet restore)
+nuget restore Auth0.OidcClient.All.sln
+
+# Build full solution (Release)
+msbuild Auth0.OidcClient.All.sln -t:rebuild -property:Configuration=Release
+
+# Build with verbose output (for CI debugging)
+msbuild Auth0.OidcClient.All.sln -t:rebuild -verbosity:diag -property:Configuration=Release
+
+# Build Core only (no mobile workloads needed)
+dotnet build src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj -c Release
+```
+
+## Test
+
+```bash
+# Run unit tests (after a full solution build)
+dotnet test **\bin\**\*UnitTests.dll
+
+# Run Core unit tests directly (after dotnet build on Core)
+dotnet test test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
+```
+
+## Format / Lint
+
+```bash
+# Check formatting (CI-equivalent)
+dotnet format --verify-no-changes
+
+# Auto-fix formatting
+dotnet format
+
+# Build with warnings-as-errors (lint equivalent)
+dotnet build /warnaserror src/Auth0.OidcClient.Core/Auth0.OidcClient.Core.csproj
+```
+
+## Clean
+
+```bash
+dotnet clean Auth0.OidcClient.All.sln
+# Or manually remove bin/ and obj/ from each project directory
+```

--- a/src/Auth0.OidcClient.Core/references/docs-update.md
+++ b/src/Auth0.OidcClient.Core/references/docs-update.md
@@ -1,0 +1,24 @@
+# Docs Update Rules
+
+## Tracked Docs
+
+| File | What it covers | Exists |
+|------|---------------|--------|
+| `README.md` | Installation, quickstart, `Auth0Client` configuration, `Auth0ClientOptions`, supported platforms, links to per-platform quickstarts | ✅ present |
+| `EXAMPLES.md` | Runnable usage samples | ❌ missing |
+
+API reference docs are generated automatically from XML doc comments via DocFX on release — do not edit `docs/` manually.
+
+## When You Change Code, Update These Docs
+
+| When this changes | Update these docs |
+|-------------------|-------------------|
+| Public API surface (`IAuth0Client`, `Auth0ClientBase` methods) | `README.md` (usage section) |
+| `Auth0ClientOptions` properties (add, remove, rename, or change defaults) | `README.md` (configuration section) |
+| Authentication / OIDC flow behavior | `README.md` (quickstart) |
+| Supported platforms or minimum .NET targets | `README.md` (requirements / installation) |
+| NuGet package names | `README.md` (installation section) |
+| Any new public method added | Add a usage sample to `README.md`; create `EXAMPLES.md` if adding a runnable demo |
+| Any public method removed or renamed | Remove/update all references in `README.md` |
+
+> Update `README.md` in the same PR — do not defer to a follow-up PR.

--- a/src/Auth0.OidcClient.Core/references/pitfalls.md
+++ b/src/Auth0.OidcClient.Core/references/pitfalls.md
@@ -1,0 +1,25 @@
+# Common Pitfalls
+
+## 1. Full solution build requires Windows
+
+The solution includes Android, iOS, and MAUI projects that require mobile workloads only available on Windows CI (`windows-2022`). Running `msbuild Auth0.OidcClient.All.sln` on macOS/Linux will fail for mobile packages. Build Core only (`dotnet build src/Auth0.OidcClient.Core/…`) if you're on a non-Windows machine.
+
+## 2. `nuget restore` before `msbuild`
+
+Use `nuget restore Auth0.OidcClient.All.sln` (the legacy NuGet CLI), not `dotnet restore`, before calling `msbuild`. The solution uses `packages.config`-style restore for some legacy projects; `dotnet restore` does not handle these.
+
+## 3. Version number in two places
+
+Each package has `<Version>` in its `*.csproj` and a matching `<version>` in its `nuget/*.nuspec`. The release workflow reads from the nuspec; both must stay in sync. Updating one without the other causes a version mismatch on the published NuGet package.
+
+## 4. `Auth0.OidcClient.Android` is deprecated
+
+New Android integrations should use `Auth0.OidcClient.AndroidX`. The legacy `Auth0.OidcClient.Android` package relies on deprecated Android support libraries and cannot target .NET 6+. Don't add features to the Android package — direct them to AndroidX.
+
+## 5. ID token validation is security-critical
+
+`IdTokenValidator` performs issuer, audience, nonce, expiry, and (optionally) signature verification. Weakening or bypassing any check — even in tests — must go through review. Use `NoSignatureVerifier` only in unit tests, never in production code paths.
+
+## 6. `Directory.Build.props` suppresses EOL workload warnings
+
+The `CheckEolWorkloads=false` setting in `Directory.Build.props` intentionally suppresses end-of-life workload warnings in CI. Don't remove it — it prevents CI noise for legacy platform targets that are still supported.

--- a/src/Auth0.OidcClient.Core/references/testing.md
+++ b/src/Auth0.OidcClient.Core/references/testing.md
@@ -1,0 +1,37 @@
+# Testing
+
+## Framework
+
+- **xUnit** 2.x — test runner and assertions
+- **Moq** 4.x — mocking framework
+- Tests live in `test/Auth0.OidcClient.Core.UnitTests/`
+
+## Running Tests
+
+```bash
+# Run unit tests (after building the solution)
+dotnet test **\bin\**\*UnitTests.dll
+
+# Run Core tests directly (no full solution build required)
+dotnet test test/Auth0.OidcClient.Core.UnitTests/Auth0.OidcClient.Core.UnitTests.csproj
+```
+
+The default test suite is unit-only — no credentials or live Auth0 tenant required.
+
+## Test Conventions
+
+- Test class names end in `Tests` (e.g., `IdTokenValidatorTests`)
+- Test method names describe the scenario: `[MethodName]_Should[Behavior]_When[Condition]` or plain descriptive names
+- Use `[Theory]` + `[InlineData]` for parameterised cases, `[Fact]` for single assertions
+- Arrange/Act/Assert structure — one assertion per logical concern
+
+## Mocking & Test Utilities
+
+- `JwtTokenFactory` — builds signed/unsigned JWTs for test scenarios
+- `NoSignatureVerifier` — stub `ISignatureVerifier` that skips cryptographic verification
+- `Data/mockJsonWebKeySet.json` — fixture JWKS for JWKS-endpoint tests; loaded via `CopyToOutputDirectory: PreserveNewest`
+- Use `Mock<T>` from Moq for interface dependencies; `mock.Setup(…).Returns(…)` pattern is standard in this codebase
+
+## Coverage
+
+No coverage threshold is enforced in CI. Focus coverage on `Tokens/` (the security-critical path) and `Auth0ClientBase` login/logout flows.

--- a/src/Auth0.OidcClient.MAUI.Platforms.Windows/AGENTS.md
+++ b/src/Auth0.OidcClient.MAUI.Platforms.Windows/AGENTS.md
@@ -1,0 +1,1 @@
+@./CLAUDE.md

--- a/src/Auth0.OidcClient.MAUI.Platforms.Windows/CLAUDE.md
+++ b/src/Auth0.OidcClient.MAUI.Platforms.Windows/CLAUDE.md
@@ -1,0 +1,85 @@
+# AI Agent Guidelines for Auth0.OidcClient.MAUI.Platforms.Windows
+
+## Project Structure
+
+```
+src/Auth0.OidcClient.MAUI.Platforms.Windows/
+└── Auth0.OidcClient.MAUI.Platforms.Windows.csproj   # Windows-specific MAUI browser integration
+test/Auth0.OidcClient.MAUI.Platforms.Windows.UnitTests/
+└── Auth0.OidcClient.MAUI.Platforms.Windows.UnitTests.csproj
+```
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run tests before committing: build the solution then `dotnet test **\bin\**\*UnitTests.dll`
+- Make surgical changes — touch only what the request requires
+- PascalCase for public types/members; `_camelCase` for private fields
+- Update `README.md` in the same PR when changing the public API
+- When adding a new outbound Auth0 request path: route through `AppendTelemetry()` in `Auth0ClientBase`
+- Keep `<Version>` in the `.csproj` in sync with the corresponding `.nuspec`
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first**
+- Adding new NuGet dependencies
+- Changing Windows-specific redirect/callback handling
+- Modifying `Directory.Build.props` or `global.json`
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, or tokens
+- Log ID tokens, access tokens, or refresh tokens
+- Modify `obj/` or `bin/` output by hand
+- Break backward compatibility without approval
+
+---
+
+## Security Considerations
+
+- **PKCE** — authentication flows use PKCE via `Auth0ClientBase`; do not bypass
+- **Token logging** — never log tokens in debug output or exceptions
+- **Windows WebAuthenticationBroker** — redirect URI registration must match the Auth0 dashboard allowed callback URLs
+
+---
+
+## Commands
+
+```bash
+nuget restore Auth0.OidcClient.All.sln
+msbuild Auth0.OidcClient.All.sln -t:rebuild -property:Configuration=Release
+dotnet test **\bin\**\*UnitTests.dll
+dotnet format --verify-no-changes
+```
+
+---
+
+## Testing
+
+Unit tests live in `test/Auth0.OidcClient.MAUI.Platforms.Windows.UnitTests/`.
+
+---
+
+## Code Style
+
+PascalCase public members, `_camelCase` private fields, async methods end in `Async`. XML doc comments on public members.
+
+---
+
+## Common Pitfalls
+
+- Build requires Windows; MAUI workloads must be installed (`dotnet workload install android ios maui`)
+- Coordinate changes with `Auth0.OidcClient.MAUI` — they share the MAUI user experience
+
+---
+
+## Docs Update Rules
+
+| File | What it covers | Exists |
+|------|---------------|--------|
+| `README.md` (repo root) | Installation, MAUI platform docs | ✅ present |
+
+Update `README.md` in the same PR when changing public API or Windows-specific behavior.

--- a/src/Auth0.OidcClient.MAUI/AGENTS.md
+++ b/src/Auth0.OidcClient.MAUI/AGENTS.md
@@ -1,0 +1,1 @@
+@./CLAUDE.md

--- a/src/Auth0.OidcClient.MAUI/CLAUDE.md
+++ b/src/Auth0.OidcClient.MAUI/CLAUDE.md
@@ -1,0 +1,94 @@
+# AI Agent Guidelines for Auth0.OidcClient.MAUI
+
+## Project Structure
+
+```
+src/Auth0.OidcClient.MAUI/
+├── Auth0.OidcClient.MAUI.csproj   # MAUI multi-platform targets
+├── Auth0Client.cs                  # Platform-specific Auth0Client subclass
+└── README.md                       # Package-specific install/usage notes
+src/Auth0.OidcClient.MAUI.Platforms.Windows/
+└── Auth0.OidcClient.MAUI.Platforms.Windows.csproj  # Windows-specific MAUI implementation
+```
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run tests before committing: `dotnet test **\bin\**\*UnitTests.dll` (build the solution first)
+- Make surgical changes — touch only what the request requires
+- Follow PascalCase for public types/members; `_camelCase` for private fields
+- Update `README.md` (repo root) and the package-level `README.md` in the same PR when changing the public API or configuration
+- When adding a **new outbound request path to Auth0**: route it through `AppendTelemetry()` in `Auth0ClientBase` so it carries the `auth0Client` parameter — preserve `Auth0ClientOptions.EnableTelemetry` opt-out
+- Keep `<Version>` in `Auth0.OidcClient.MAUI.csproj` in sync with `nuget/Auth0.OidcClient.MAUI.nuspec`
+- Maintain existing minimum MAUI platform targets
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first**
+- Adding new NuGet dependencies
+- Changing the `IBrowser` implementation in a way that alters redirect/callback handling
+- Raising minimum platform targets
+- Modifying `Directory.Build.props` or `global.json` (affects all packages)
+- Bumping dependency versions
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, or tokens
+- Log ID tokens, access tokens, or refresh tokens
+- Remove or skip failing tests
+- Modify `obj/` or `bin/` output by hand
+- Break backward compatibility without approval
+
+---
+
+## Security Considerations
+
+- **PKCE** — authentication flows use PKCE via `Auth0ClientBase`; do not bypass
+- **Token logging** — never log tokens in debug output or exceptions
+- **Redirect URI** — MAUI apps use custom URI schemes for callbacks; do not change the scheme without verifying allowed callback URLs in the Auth0 dashboard
+
+---
+
+## Commands
+
+Build the full solution (requires Windows with Android/iOS/MAUI workloads):
+
+```bash
+nuget restore Auth0.OidcClient.All.sln
+msbuild Auth0.OidcClient.All.sln -t:rebuild -property:Configuration=Release
+dotnet test **\bin\**\*UnitTests.dll
+dotnet format --verify-no-changes
+```
+
+---
+
+## Testing
+
+No dedicated unit test project exists for this package. Test changes via `test/Auth0.OidcClient.Core.UnitTests/` (Core logic) and manually on a MAUI device/emulator.
+
+---
+
+## Code Style
+
+PascalCase public members, `_camelCase` private fields, async methods end in `Async`. XML doc comments on public members. See Core's `references/code-style.md` for full conventions.
+
+---
+
+## Common Pitfalls
+
+- Full solution build requires Windows; MAUI workloads (`dotnet workload install android ios maui`) must be installed
+- MAUI Windows platform-specific code lives in `Auth0.OidcClient.MAUI.Platforms.Windows` — check both packages when making Windows-specific changes
+
+---
+
+## Docs Update Rules
+
+| File | What it covers | Exists |
+|------|---------------|--------|
+| `README.md` (repo root) | Installation, platform quickstart links | ✅ present |
+| `src/Auth0.OidcClient.MAUI/README.md` | MAUI-specific install/usage | ✅ present |
+
+Update both READMEs in the same PR when changing the public API or MAUI-specific configuration.

--- a/src/Auth0.OidcClient.UWP/AGENTS.md
+++ b/src/Auth0.OidcClient.UWP/AGENTS.md
@@ -1,0 +1,1 @@
+@./CLAUDE.md

--- a/src/Auth0.OidcClient.UWP/CLAUDE.md
+++ b/src/Auth0.OidcClient.UWP/CLAUDE.md
@@ -1,0 +1,86 @@
+# AI Agent Guidelines for Auth0.OidcClient.UWP
+
+## Project Structure
+
+```
+src/Auth0.OidcClient.UWP/
+└── Auth0.OidcClient.UWP.csproj   # UWP Web Authentication Broker integration
+test/UWP/
+├── UWP.csproj
+└── project.json                   # Interactive test app (not automated unit tests)
+```
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run tests before committing: build the solution then `dotnet test **\bin\**\*UnitTests.dll`
+- Make surgical changes — touch only what the request requires
+- PascalCase for public types/members; `_camelCase` for private fields
+- Update `README.md` in the same PR when changing public API or configuration
+- When adding a new outbound Auth0 request path: route through `AppendTelemetry()` in `Auth0ClientBase`
+- Keep `<Version>` in the `.csproj` in sync with `nuget/Auth0.OidcClient.UWP.nuspec`
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first**
+- Adding new NuGet or Windows UWP dependencies
+- Changing Web Authentication Broker redirect/callback behavior
+- Modifying `Directory.Build.props` or `global.json`
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, or tokens
+- Log ID tokens, access tokens, or refresh tokens
+- Modify `obj/` or `bin/` output by hand
+- Break backward compatibility without approval
+
+---
+
+## Security Considerations
+
+- **PKCE** — authentication flows use PKCE via `Auth0ClientBase`; do not bypass
+- **Token logging** — never log tokens in debug output or exceptions
+- **Web Authentication Broker** — UWP uses `WebAuthenticationBroker`; callback URI registration must match Auth0 allowed callback URLs
+
+---
+
+## Commands
+
+```bash
+nuget restore Auth0.OidcClient.All.sln
+msbuild Auth0.OidcClient.All.sln -t:rebuild -property:Configuration=Release
+dotnet test **\bin\**\*UnitTests.dll
+dotnet format --verify-no-changes
+```
+
+---
+
+## Testing
+
+No automated unit tests for this package. Validate via the `test/UWP/` interactive test app.
+
+---
+
+## Code Style
+
+PascalCase public members, `_camelCase` private fields, async methods end in `Async`. XML doc comments on public members.
+
+---
+
+## Common Pitfalls
+
+- UWP builds require Windows and UWP workload support; `project.json` in `test/UWP/` is a legacy format
+- UWP's `WebAuthenticationBroker` has specific URI scheme requirements — test on a real device before release
+
+---
+
+## Docs Update Rules
+
+| File | What it covers | Exists |
+|------|---------------|--------|
+| `README.md` (repo root) | Installation (`Auth0.OidcClient.UWP`), UWP quickstart link | ✅ present |
+
+Update `README.md` in the same PR when changing public API or UWP-specific configuration.

--- a/src/Auth0.OidcClient.WPF/AGENTS.md
+++ b/src/Auth0.OidcClient.WPF/AGENTS.md
@@ -1,0 +1,1 @@
+@./CLAUDE.md

--- a/src/Auth0.OidcClient.WPF/CLAUDE.md
+++ b/src/Auth0.OidcClient.WPF/CLAUDE.md
@@ -1,0 +1,86 @@
+# AI Agent Guidelines for Auth0.OidcClient.WPF
+
+## Project Structure
+
+```
+src/Auth0.OidcClient.WPF/
+└── Auth0.OidcClient.WPF.csproj   # WPF desktop browser integration
+test/WPF/
+└── WPF.csproj                     # Interactive test app (not automated unit tests)
+```
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run tests before committing: build the solution then `dotnet test **\bin\**\*UnitTests.dll`
+- Make surgical changes — touch only what the request requires
+- PascalCase for public types/members; `_camelCase` for private fields
+- Update `README.md` in the same PR when changing public API or configuration
+- When adding a new outbound Auth0 request path: route through `AppendTelemetry()` in `Auth0ClientBase`
+- Keep `<Version>` in the `.csproj` in sync with `nuget/Auth0.OidcClient.WPF.nuspec`
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first**
+- Adding new NuGet or Windows dependencies
+- Changing system browser / embedded WebView redirect handling
+- Modifying `Directory.Build.props` or `global.json`
+- Raising minimum Windows target
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, or tokens
+- Log ID tokens, access tokens, or refresh tokens
+- Modify `obj/` or `bin/` output by hand
+- Break backward compatibility without approval
+
+---
+
+## Security Considerations
+
+- **PKCE** — authentication flows use PKCE via `Auth0ClientBase`; do not bypass
+- **Token logging** — never log tokens in debug output or exceptions
+- **Redirect URI** — WPF uses a local loopback or custom URI scheme for callbacks; changes must be reflected in Auth0 allowed callback URLs
+
+---
+
+## Commands
+
+```bash
+nuget restore Auth0.OidcClient.All.sln
+msbuild Auth0.OidcClient.All.sln -t:rebuild -property:Configuration=Release
+dotnet test **\bin\**\*UnitTests.dll
+dotnet format --verify-no-changes
+```
+
+---
+
+## Testing
+
+No automated unit tests for this package. Validate via the `test/WPF/` interactive test app.
+
+---
+
+## Code Style
+
+PascalCase public members, `_camelCase` private fields, async methods end in `Async`. XML doc comments on public members.
+
+---
+
+## Common Pitfalls
+
+- WPF targets Windows only; the `test/WPF/` app requires a Windows environment to run
+- WPF browser integration typically uses the system default browser; changes to redirect handling affect the callback URL registration
+
+---
+
+## Docs Update Rules
+
+| File | What it covers | Exists |
+|------|---------------|--------|
+| `README.md` (repo root) | Installation (`Auth0.OidcClient.WPF`), WPF/WinForms quickstart link | ✅ present |
+
+Update `README.md` in the same PR when changing public API or WPF-specific configuration.

--- a/src/Auth0.OidcClient.WinForms/AGENTS.md
+++ b/src/Auth0.OidcClient.WinForms/AGENTS.md
@@ -1,0 +1,1 @@
+@./CLAUDE.md

--- a/src/Auth0.OidcClient.WinForms/CLAUDE.md
+++ b/src/Auth0.OidcClient.WinForms/CLAUDE.md
@@ -1,0 +1,85 @@
+# AI Agent Guidelines for Auth0.OidcClient.WinForms
+
+## Project Structure
+
+```
+src/Auth0.OidcClient.WinForms/
+└── Auth0.OidcClient.WinForms.csproj   # WinForms desktop browser integration
+test/WinForms/
+└── WinForms.csproj                     # Interactive test app (not automated unit tests)
+```
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run tests before committing: build the solution then `dotnet test **\bin\**\*UnitTests.dll`
+- Make surgical changes — touch only what the request requires
+- PascalCase for public types/members; `_camelCase` for private fields
+- Update `README.md` in the same PR when changing public API or configuration
+- When adding a new outbound Auth0 request path: route through `AppendTelemetry()` in `Auth0ClientBase`
+- Keep `<Version>` in the `.csproj` in sync with `nuget/Auth0.OidcClient.WinForms.nuspec`
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first**
+- Adding new NuGet or Windows dependencies
+- Changing browser redirect/callback handling
+- Modifying `Directory.Build.props` or `global.json`
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, or tokens
+- Log ID tokens, access tokens, or refresh tokens
+- Modify `obj/` or `bin/` output by hand
+- Break backward compatibility without approval
+
+---
+
+## Security Considerations
+
+- **PKCE** — authentication flows use PKCE via `Auth0ClientBase`; do not bypass
+- **Token logging** — never log tokens in debug output or exceptions
+- **Redirect URI** — WinForms uses a local loopback or custom URI scheme; changes must be reflected in Auth0 allowed callback URLs
+
+---
+
+## Commands
+
+```bash
+nuget restore Auth0.OidcClient.All.sln
+msbuild Auth0.OidcClient.All.sln -t:rebuild -property:Configuration=Release
+dotnet test **\bin\**\*UnitTests.dll
+dotnet format --verify-no-changes
+```
+
+---
+
+## Testing
+
+No automated unit tests for this package. Validate via the `test/WinForms/` interactive test app.
+
+---
+
+## Code Style
+
+PascalCase public members, `_camelCase` private fields, async methods end in `Async`. XML doc comments on public members.
+
+---
+
+## Common Pitfalls
+
+- WinForms targets Windows only; the `test/WinForms/` app requires a Windows environment
+- WPF and WinForms share the same quickstart docs — coordinate changes that affect both
+
+---
+
+## Docs Update Rules
+
+| File | What it covers | Exists |
+|------|---------------|--------|
+| `README.md` (repo root) | Installation (`Auth0.OidcClient.WinForms`), WPF/WinForms quickstart link | ✅ present |
+
+Update `README.md` in the same PR when changing public API or WinForms-specific configuration.

--- a/src/Auth0.OidcClient.iOS/AGENTS.md
+++ b/src/Auth0.OidcClient.iOS/AGENTS.md
@@ -1,0 +1,1 @@
+@./CLAUDE.md

--- a/src/Auth0.OidcClient.iOS/CLAUDE.md
+++ b/src/Auth0.OidcClient.iOS/CLAUDE.md
@@ -1,0 +1,88 @@
+# AI Agent Guidelines for Auth0.OidcClient.iOS
+
+## Project Structure
+
+```
+src/Auth0.OidcClient.iOS/
+└── Auth0.OidcClient.iOS.csproj   # iOS browser integration (ASWebAuthenticationSession)
+test/iOS/
+└── iOS.csproj                     # Interactive test app (not automated unit tests)
+```
+
+---
+
+## Boundaries
+
+### ✅ Always Do
+
+- Run tests before committing: build the solution then `dotnet test **\bin\**\*UnitTests.dll`
+- Make surgical changes — touch only what the request requires
+- PascalCase for public types/members; `_camelCase` for private fields
+- Update `README.md` in the same PR when changing public API or configuration
+- When adding a new outbound Auth0 request path: route through `AppendTelemetry()` in `Auth0ClientBase`
+- Keep `<Version>` in the `.csproj` in sync with `nuget/Auth0.OidcClient.iOS.nuspec`
+
+### ⚠️ Ask First
+
+- **Any breaking change — always ask first**
+- Adding new NuGet or iOS framework dependencies
+- Changing `ASWebAuthenticationSession` / `SFSafariViewController` redirect handling
+- Modifying `Directory.Build.props` or `global.json`
+- Raising minimum iOS deployment target
+
+### 🚫 Never Do
+
+- Commit secrets, API keys, or tokens
+- Log ID tokens, access tokens, or refresh tokens
+- Modify `obj/` or `bin/` output by hand
+- Break backward compatibility without approval
+
+---
+
+## Security Considerations
+
+- **PKCE** — authentication flows use PKCE via `Auth0ClientBase`; do not bypass
+- **Token logging** — never log tokens in debug output or exceptions
+- **Custom URL scheme** — callback URI must match Auth0 dashboard allowed callback URLs; changes require updating both the iOS `Info.plist` and Auth0 configuration
+
+---
+
+## Commands
+
+```bash
+# Requires Windows with iOS workload
+nuget restore Auth0.OidcClient.All.sln
+msbuild Auth0.OidcClient.All.sln -t:rebuild -property:Configuration=Release
+dotnet test **\bin\**\*UnitTests.dll
+dotnet format --verify-no-changes
+```
+
+---
+
+## Testing
+
+No automated unit tests for this package. Validate via the `test/iOS/` interactive test app on simulator or device.
+
+---
+
+## Code Style
+
+PascalCase public members, `_camelCase` private fields, async methods end in `Async`. XML doc comments on public members.
+
+---
+
+## Common Pitfalls
+
+- iOS build requires the iOS workload (`dotnet workload install ios`); full solution build requires Windows CI
+- `ASWebAuthenticationSession` requires the custom URL scheme registered in `Info.plist` of the host app
+- Coordinating `ephemeralWebBrowserSession` behavior changes with the iOS Xamarin quickstart docs
+
+---
+
+## Docs Update Rules
+
+| File | What it covers | Exists |
+|------|---------------|--------|
+| `README.md` (repo root) | Installation (`Auth0.OidcClient.iOS`), iOS/Xamarin quickstart link | ✅ present |
+
+Update `README.md` in the same PR when changing public API or iOS-specific configuration.


### PR DESCRIPTION
### Changes

Adds a layered set of `CLAUDE.md` / `AGENTS.md` files so AI coding agents have accurate, repo-specific context when working in this codebase.

### References

### Testing

- [ ] This change adds unit test coverage
- [ ] This change adds integration test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
- [x] All code guidelines in the [CONTRIBUTING documentation](../CONTRIBUTING.md) have been run/followed
